### PR TITLE
Headshots api endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,37 @@
+# API Documentation
+The platform exposes a REST API for public consumption.
+
+NOTE: __This documentation is only temporary and will be replaced by a proper documentation.__
+
+## Get headshots
+ URL: `GET /api/headshots` \
+ Public: Yes 
+
+* The collection envelope is called items
+* Every item has the following fields
+    - profile_id: integer The player profile id
+    - target_id: integer The target id
+    - target_name: string The target name
+    - timer: integer The time in seconds for completion
+    - first: boolean If the headshot was first
+    - rating: integer The user provided difficulty rating for the target
+    - created_at: datatime The headshot was achieved
+
+**Example**
+```json
+{
+  "profile_id":"177952",
+  "target_id":24,
+  "target_name":"tweek",
+  "timer":26740,
+  "first":false,
+  "rating":-1,
+  "created_at":"2020-09-11 04:15:47"
+}
+```
+
+Parameters:
+* `filter`: filter through `filter[field_name]=field_value` example: `filter[profile_id]=1337`
+* `fields`: selecting fields through `fields=field_name,field_name...` syntax eg `fields=target_name,profile_id` to select only the target name and profile_id
+* `sort`: sorting through sort eg sort=-created_at,profile_id to sort created_at descending and profile_id ascending
+* `per-page`: limiting results per page through per-page eg per-page=100, accepted values in the range of [1...100]

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,21 +1,21 @@
 # API Documentation
 The platform exposes a REST API for public consumption.
 
-NOTE: __This documentation is only temporary and will be replaced by a proper documentation.__
+NOTE: __This documentation is only temporary and will be replaced by a Swagger.io/Postman documentation.__
 
 ## Get headshots
  URL: `GET /api/headshots` \
- Public: Yes 
+ Public: Yes
 
 * The collection envelope is called items
 * Every item has the following fields
-    - profile_id: integer The player profile id
-    - target_id: integer The target id
-    - target_name: string The target name
-    - timer: integer The time in seconds for completion
-    - first: boolean If the headshot was first
-    - rating: integer The user provided difficulty rating for the target
-    - created_at: datatime The headshot was achieved
+    - `profile_id`: integer The player profile id
+    - `target_id`: integer The target id
+    - `target_name`: string The target name
+    - `timer`: integer The time in seconds for completion
+    - `first`: boolean If the headshot was first
+    - `rating`: integer The user provided difficulty rating for the target
+    - `created_at`: datatime The headshot was achieved
 
 **Example**
 ```json

--- a/frontend/modules/api/Module.php
+++ b/frontend/modules/api/Module.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace app\modules\api;
+
+/**
+ * API module definition class
+ */
+class Module extends \yii\base\Module
+{
+    /**
+     * {@inheritdoc}
+     */
+    public $controllerNamespace='app\modules\api\controllers';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+      parent::init();
+    }
+}

--- a/frontend/modules/api/Module.php
+++ b/frontend/modules/api/Module.php
@@ -10,7 +10,7 @@ class Module extends \yii\base\Module
     /**
      * {@inheritdoc}
      */
-    public $controllerNamespace='app\modules\api\controllers';
+    public $controllerNamespace='\app\modules\api\controllers';
 
     /**
      * {@inheritdoc}
@@ -18,5 +18,7 @@ class Module extends \yii\base\Module
     public function init()
     {
       parent::init();
+      \Yii::$app->response->format = \yii\web\Response::FORMAT_JSON;
+      //\Yii::$app->errorHandler->errorAction = 'api/default/error';
     }
 }

--- a/frontend/modules/api/controllers/HeadshotController.php
+++ b/frontend/modules/api/controllers/HeadshotController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace app\modules\api\controllers;
+
+use Yii;
+use yii\helpers\ArrayHelper;
+use yii\data\ActiveDataProvider;
+
+class HeadshotController extends \yii\rest\ActiveController
+{
+  public $modelClass="\app\modules\game\models\Headshot";
+  public $serializer=[
+        'class' => 'yii\rest\Serializer',
+        'collectionEnvelope' => 'items',
+    ];
+
+//    public function behaviors()
+//      {
+//          return ArrayHelper::merge(parent::behaviors(), [
+//              [
+//                  'class' => 'yii\filters\ContentNegotiator',
+//                  'formats' => [
+//                      'application/json' => \yii\web\Response::FORMAT_JSON,
+//                      'application/xml' => \yii\web\Response::FORMAT_XML,
+//                  ],
+//              ],
+//          ]);
+//      }
+
+  public function actions()
+  {
+      $actions = parent::actions();
+
+      // disable the "delete", "create", "view","update" actions
+      unset($actions['delete'], $actions['create'],$actions['view'],$actions['update']);
+      $actions['index']['prepareDataProvider'] = [$this, 'prepareDataProvider'];
+
+      return $actions;
+  }
+
+  public function prepareDataProvider()
+  {
+    //\Yii::$app->response->format=\yii\web\Response::FORMAT_JSON;
+
+    $requestParams = Yii::$app->getRequest()->getBodyParams();
+    if (empty($requestParams)) {
+        $requestParams = Yii::$app->getRequest()->getQueryParams();
+    }
+    $query = (new \yii\db\Query())
+        ->select(['profile.id as profile_id', 'target_id','timer','rating','headshot.created_at'])
+        ->from('headshot')
+        ->leftJoin('profile', '`profile`.`player_id` = `headshot`.`player_id`')
+        ->where(['profile.visibility'=>'public'])
+        ->orderBy(['headshot.created_at'=>SORT_DESC,'target_id'=>SORT_ASC]);
+
+    return new ActiveDataProvider([
+      'query'=>$query,
+      'pagination' => [
+          'params' => $requestParams,
+      ],
+      'sort' => [
+          'params' => $requestParams,
+      ],
+    ]);
+
+  }
+}

--- a/frontend/modules/api/controllers/HeadshotController.php
+++ b/frontend/modules/api/controllers/HeadshotController.php
@@ -5,15 +5,14 @@ namespace app\modules\api\controllers;
 use Yii;
 use yii\helpers\ArrayHelper;
 use yii\data\ActiveDataProvider;
-
+use yii\data\ActiveDataFilter;
 class HeadshotController extends \yii\rest\ActiveController
 {
-  public $modelClass="\app\modules\game\models\Headshot";
+  public $modelClass="\app\modules\api\models\Headshot";
   public $serializer=[
         'class' => 'yii\rest\Serializer',
         'collectionEnvelope' => 'items',
     ];
-
 //    public function behaviors()
 //      {
 //          return ArrayHelper::merge(parent::behaviors(), [
@@ -40,28 +39,66 @@ class HeadshotController extends \yii\rest\ActiveController
 
   public function prepareDataProvider()
   {
-    //\Yii::$app->response->format=\yii\web\Response::FORMAT_JSON;
+    \Yii::$app->response->format=\yii\web\Response::FORMAT_JSON;
 
     $requestParams = Yii::$app->getRequest()->getBodyParams();
     if (empty($requestParams)) {
         $requestParams = Yii::$app->getRequest()->getQueryParams();
     }
-    $query = (new \yii\db\Query())
-        ->select(['profile.id as profile_id', 'target_id','timer','rating','headshot.created_at'])
-        ->from('headshot')
-        ->leftJoin('profile', '`profile`.`player_id` = `headshot`.`player_id`')
-        ->where(['profile.visibility'=>'public'])
-        ->orderBy(['headshot.created_at'=>SORT_DESC,'target_id'=>SORT_ASC]);
+    $filter = new ActiveDataFilter([
+        'searchModel' => '\app\modules\api\models\HeadshotSearch',
+        'attributeMap' => [
+            'profile_id' => 'profile.id',
+            'target_name' => 'target.name',
+            'created_at' => 'headshot.created_at',
+            'timer' => 'headshot.timer'
+        ]
+    ]);
 
-    return new ActiveDataProvider([
+    $filterCondition = null;
+
+    // You may load filters from any source. For example,
+    // if you prefer JSON in request body,
+    // use Yii::$app->request->getBodyParams() below:
+    if ($filter->load(\Yii::$app->request->get())) {
+        $filterCondition = $filter->build();
+        if ($filterCondition === false) {
+            // Serializer would get errors out of it
+            return $filter;
+        }
+    }
+    $query=\app\modules\api\models\Headshot::find()->rest();
+    if ($filterCondition !== null) {
+        $query->andWhere($filterCondition);
+    }
+
+    $dataProvider=new ActiveDataProvider([
       'query'=>$query,
       'pagination' => [
+          'pageSizeLimit' => [1,100],
+          'defaultPageSize'=>10,
           'params' => $requestParams,
       ],
       'sort' => [
-          'params' => $requestParams,
+        'defaultOrder' => ['created_at' => SORT_DESC],
+        'params' => $requestParams,
       ],
     ]);
-
+    $dataProvider->setSort([
+        'attributes' => array_merge(
+            $dataProvider->getSort()->attributes,
+            [
+              'profile_id' => [
+                  'asc' => ['profile.id' => SORT_ASC],
+                  'desc' => ['profile.id' => SORT_DESC],
+              ],
+              'target_name' => [
+                  'asc' => ['target.name' => SORT_ASC],
+                  'desc' => ['target.name' => SORT_DESC],
+              ],
+            ]
+        ),
+    ]);
+    return $dataProvider;
   }
 }

--- a/frontend/modules/api/models/Headshot.php
+++ b/frontend/modules/api/models/Headshot.php
@@ -5,19 +5,15 @@ namespace app\modules\api\models;
 use Yii;
 
 /**
- * This is the model class for table "headshot".
+ * This is the model class for table "headshot" for the REST API
  *
- * @property int $player_id
+ * @property int $profile_id
  * @property int $target_id
- * @property string|null $created_at
+ * @property string $target_name
  * @property int $timer
  * @property int $rating
  * @property boolean $first
- * @property string|null $rated
- *
- * @property Player $player
- * @property Target $target
- * @property Writeup $writeup
+ * @property string|null $created_at
  */
 class Headshot extends \app\modules\game\models\Headshot
 {
@@ -41,11 +37,9 @@ class Headshot extends \app\modules\game\models\Headshot
           'created_at'
       ];
   }
+
   public function extraFields()
   {
     return [];
-    //  return ['profile','target'];
   }
-
-
 }

--- a/frontend/modules/api/models/Headshot.php
+++ b/frontend/modules/api/models/Headshot.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace app\modules\api\models;
+
+use Yii;
+
+/**
+ * This is the model class for table "headshot".
+ *
+ * @property int $player_id
+ * @property int $target_id
+ * @property string|null $created_at
+ * @property int $timer
+ * @property int $rating
+ * @property boolean $first
+ * @property string|null $rated
+ *
+ * @property Player $player
+ * @property Target $target
+ * @property Writeup $writeup
+ */
+class Headshot extends \app\modules\game\models\Headshot
+{
+  public $profile_id;
+  public $target_name;
+
+  public static function find()
+  {
+      return new HeadshotQuery(get_called_class());
+  }
+
+  public function fields()
+  {
+      return [
+          'profile_id',
+          'target_id',
+          'target_name',
+          'timer',
+          'first',
+          'rating',
+          'created_at'
+      ];
+  }
+  public function extraFields()
+  {
+    return [];
+    //  return ['profile','target'];
+  }
+
+
+}

--- a/frontend/modules/api/models/HeadshotQuery.php
+++ b/frontend/modules/api/models/HeadshotQuery.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace app\modules\api\models;
+
+/**
+ * This is the ActiveQuery class for [[Headshot]].
+ *
+ * @see Headshot
+ */
+class HeadshotQuery extends \yii\db\ActiveQuery
+{
+    public function rest()
+    {
+        return $this->select(['headshot.*','profile.id as profile_id','target.name as target_name'])->joinWith(['target','profile'])->andWhere(['profile.visibility'=>'public']);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return Headshot[]|array
+     */
+    public function all($db=null)
+    {
+        return parent::all($db);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return Headshot|array|null
+     */
+    public function one($db=null)
+    {
+        return parent::one($db);
+    }
+}

--- a/frontend/modules/api/models/HeadshotSearch.php
+++ b/frontend/modules/api/models/HeadshotSearch.php
@@ -1,0 +1,24 @@
+<?php
+namespace app\modules\api\models;
+
+use yii\base\Model;
+
+class HeadshotSearch extends Model
+{
+    public $target_id;
+    public $profile_id;
+    public $created_at;
+    public $first;
+    public $rating;
+    public $timer;
+
+    public function rules()
+    {
+        return [
+            [['target_id','profile_id','rating','timer'], 'integer'],
+            [['first'], 'boolean'],
+            [['target_name'], 'string'],
+            [['created_at'], 'datetime']
+        ];
+    }
+}

--- a/frontend/modules/game/models/Headshot.php
+++ b/frontend/modules/game/models/Headshot.php
@@ -113,6 +113,14 @@ class Headshot extends \yii\db\ActiveRecord
     /**
      * @return \yii\db\ActiveQuery
      */
+    public function getProfile()
+    {
+        return $this->hasOne(\app\models\Profile::class, ['player_id' => 'player_id']);
+    }
+
+    /**
+     * @return \yii\db\ActiveQuery
+     */
     public function getTarget()
     {
         return $this->hasOne(Target::class, ['id' => 'target_id']);


### PR DESCRIPTION
Implement a basic headshots REST endpoint for people to query. The endpoint is available on `api/headshot/index` with UrlRules exposing it under `api/headshots`

* The collection envelope is called `items` 
* Every item has the following fields 
  * `profile_id: integer` The player profile id
  * target_id: integer The target id
  * target_name: string The target name
  * timer: integer The time in seconds for completion
  * first: boolean If the headshot was first
  * rating: integer The user provided difficulty rating for the target
  * created_at: datatime The headshot was achieved

example
```json
{
  "profile_id":"177952",
  "target_id":24,
  "target_name":"tweek",
  "timer":26740,
  "first":false,
  "rating":-1,
  "created_at":"2020-09-11 04:15:47"
}
```
The endpoint supports:
* filtering through `filter[field_name]=field_value` syntax eg `filter[profile_id]=1337`
* selecting fields through `fields=field_name,field_name...`  syntax eg `fields=target_name,profile_id` to select only the target name and profile_id 
* sorting through `sort` eg `sort=-created_at,profile_id` to sort created_at descending and profile_id ascending
* limiting results per page through `per-page` eg `per-page=100`, accepted values in the range of [1...100]
