### PR TITLE
start mysql with character set and collation

### DIFF
--- a/contrib/mysql-init.sql
+++ b/contrib/mysql-init.sql
@@ -1,3 +1,4 @@
+USE information_schema;
 DELIMITER ;;
 IF (SELECT count(*) FROM information_schema.tables WHERE table_schema = 'echoCTF' AND table_name = 'devnull' LIMIT 1)>0 THEN
   CALL echoCTF.init_mysql();

--- a/docker-compose-novpn-macvlan.yml
+++ b/docker-compose-novpn-macvlan.yml
@@ -7,6 +7,7 @@ services:
       context: .
       dockerfile: contrib/Dockerfile-mariadb
     restart: "always"
+    command: ["mysqld","--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci","--skip-character-set-client-handshake"]
     volumes:
       - data-mysql:/var/lib/mysql
     environment:

--- a/docker-compose-novpn.yml
+++ b/docker-compose-novpn.yml
@@ -7,6 +7,7 @@ services:
       context: .
       dockerfile: contrib/Dockerfile-mariadb
     restart: "always"
+    command: ["mysqld","--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci","--skip-character-set-client-handshake"]
     ports:
       - 3306:3306
       - 11211:11211

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       context: .
       dockerfile: contrib/Dockerfile-mariadb
     restart: "always"
+    command: ["mysqld","--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci","--skip-character-set-client-handshake"]
     ports:
       - 3306:3306
       - 11211:11211


### PR DESCRIPTION
also add a trick of `USE information_schema;` as first command of the 
mysql-init.sql to ensure we switch to its internal encoding.
fixes #568 