### PR TITLE
Target queries flattening

### DIFF
--- a/backend/commands/VpnController.php
+++ b/backend/commands/VpnController.php
@@ -130,18 +130,24 @@ class VpnController extends Controller
     $status['client_list']=[];
     foreach($q->all() as $entry)
     {
-      $parsed=OpenVPN::parseStatus($entry->status_log);
-      if(property_exists($parsed,'routing_table') && count($parsed->routing_table)>0)
-        $status['routing_table']=\yii\helpers\ArrayHelper::merge($status['routing_table'],$parsed->routing_table);
-      if(property_exists($parsed,'client_list') && count($parsed->client_list)>0)
-        $status['client_list']=\yii\helpers\ArrayHelper::merge($status['client_list'],$parsed->client_list);
+      try {
+        $parsed=OpenVPN::parseStatus($entry->status_log);
+        if(property_exists($parsed,'routing_table') && count($parsed->routing_table)>0)
+          $status['routing_table']=\yii\helpers\ArrayHelper::merge($status['routing_table'],$parsed->routing_table);
+        if(property_exists($parsed,'client_list') && count($parsed->client_list)>0)
+          $status['client_list']=\yii\helpers\ArrayHelper::merge($status['client_list'],$parsed->client_list);
+      }
+      catch (\Exception $e)
+      {
+
+      }
       unset($entry);
     }
     $this->stdout(  sprintf("%-5s %-10s %-10s %-18s %-10s %-10s\n", 'ID', 'Username','Local IP','Remote IP', 'Received', 'Send'), Console::BOLD);
     foreach($status['client_list'] as $entry)
     {
       $p=\app\modules\frontend\models\Player::findOne($entry->player_id);
-      $this->stdout(sprintf("%-5s %-10s %-10s %-18s %-10s %-10s\n", $entry->player_id,$p->username,$p->playerLast->vpn_local_address_octet,$entry->remote_ip_port,$entry->bytes_received,$entry->bytes_send));
+      $this->stdout(sprintf("%-5s %-10s %-10s %-18s %-10s %-10s\n", $entry->player_id,$p->username,$p->playerLast->vpn_local_address_octet,$entry->remote_ip_port,number_format($entry->bytes_received/1024).'kb',number_format($entry->bytes_send/1024).'kb'));
     }
   }
 }

--- a/backend/components/OpenVPN.php
+++ b/backend/components/OpenVPN.php
@@ -76,7 +76,7 @@ class OpenVPN extends Component
   static public function parseStatus(string $location)
   {
     $statusLines=explode("\n",file_get_contents($location));
-    if(count($statusLines))
+    if(count($statusLines)==0)
       return new stdClass;
     $status=new stdClass;
     $status->updated_at=$statusLines[1];

--- a/backend/migrations/m220514_211321_create_target_state_table.php
+++ b/backend/migrations/m220514_211321_create_target_state_table.php
@@ -1,0 +1,76 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%target_states}}`.
+ */
+class m220514_211321_create_target_state_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->createTable('{{%target_state}}', [
+            'id' => $this->integer()->notNull(),
+            'total_headshots'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'total_findings'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'total_treasures'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'player_rating'=>$this->integer()->notNull()->defaultValue(-1),
+            'timer_avg'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'total_writeups'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'approved_writeups'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'finding_points'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'treasure_points'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'total_points'=>$this->integer()->unsigned()->notNull()->defaultValue(0),
+            'on_network'=>$this->smallInteger()->unsigned()->notNull()->defaultValue(0),
+            'on_ondemand'=>$this->smallInteger()->unsigned()->notNull()->defaultValue(0),
+            'ondemand_state'=>$this->smallInteger()->notNull()->defaultValue(-1),
+            'PRIMARY KEY (id)',
+        ]);
+
+        // add foreign key for table `{{%player}}`
+        $this->addForeignKey(
+            '{{%fk-target_states-id}}',
+            '{{%target_state}}',
+            'id',
+            '{{%target}}',
+            'id',
+            'CASCADE'
+        );
+        $this->createIndex(
+            'idx-target_state-total_headshots',
+            'target_state',
+            'total_headshots'
+        );
+        $this->createIndex(
+            'idx-target_state-total_findings',
+            'target_state',
+            'total_findings'
+        );
+        $this->createIndex(
+            'idx-target_state-total_treasures',
+            'target_state',
+            'total_treasures'
+        );
+        $this->createIndex(
+            'idx-target_state-player_rating',
+            'target_state',
+            'player_rating'
+        );
+        $this->createIndex(
+            'idx-target_state-timer_avg',
+            'target_state',
+            'timer_avg'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropTable('{{%target_state}}');
+    }
+}

--- a/backend/migrations/m220514_214530_populate_target_state_with_data.php
+++ b/backend/migrations/m220514_214530_populate_target_state_with_data.php
@@ -1,0 +1,59 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220514_214530_populate_target_state_with_data
+ */
+class m220514_214530_populate_target_state_with_data extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        /**
+         * Populate the bulk of the data as taken from widget
+         */
+        $this->db->createCommand("INSERT IGNORE INTO target_state (id,total_treasures,total_findings,player_rating,total_headshots,total_writeups,approved_writeups) SELECT t.id, count(distinct treasure.id) as total_treasures, count(distinct finding.id) as total_findings, round(avg(CASE WHEN headshot.rating > -1 THEN headshot.rating END)) as player_rating,count(distinct headshot.player_id) as total_headshots, count(distinct writeup.id) as total_writeups,count(distinct (case when writeup.approved=1 then writeup.id end)) AS approved_writeups FROM target t LEFT JOIN treasure ON treasure.target_id=t.id LEFT JOIN finding ON finding.target_id=t.id LEFT JOIN headshot ON headshot.target_id=t.id LEFT JOIN writeup ON writeup.target_id=t.id GROUP BY t.id")->execute();
+        // set average timer
+        $this->db->createCommand("INSERT INTO target_state (id,timer_avg) SELECT target_id,AVG(timer) FROM headshot GROUP BY target_id ON DUPLICATE KEY UPDATE timer_avg=values(timer_avg)")->execute();
+        // set treasure points
+        $this->db->createCommand("INSERT INTO target_state (id,treasure_points) SELECT target_id,sum(points) FROM treasure GROUP BY target_id ON DUPLICATE KEY UPDATE treasure_points=values(treasure_points)")->execute();
+        // set finding points
+        $this->db->createCommand("INSERT INTO target_state (id,finding_points) SELECT target_id,sum(points) FROM finding GROUP BY target_id ON DUPLICATE KEY UPDATE finding_points=values(finding_points)")->execute();
+
+        // set the ondemand target status
+        $this->db->createCommand("INSERT INTO target_state (id, on_ondemand,ondemand_state) SELECT target_id,1,{{%state}} FROM target_ondemand ON DUPLICATE KEY UPDATE on_ondemand=values(on_ondemand),ondemand_state=values(ondemand_state)")->execute();
+
+        // Set the on_network flags
+        $this->db->createCommand("INSERT INTO target_state (id, on_network) SELECT DISTINCT target_id,1 FROM network_target ON DUPLICATE KEY UPDATE on_network=values(on_network)")->execute();
+
+        // Set the total_points for records
+        $this->db->createCommand("UPDATE target_state SET total_points=finding_points+treasure_points")->execute();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        echo "m220514_214530_populate_target_state_with_data cannot be reverted.\n";
+
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m220514_214530_populate_target_state_with_data cannot be reverted.\n";
+
+        return false;
+    }
+    */
+}

--- a/backend/migrations/m220514_224351_create_tai_treasure_trigger.php
+++ b/backend/migrations/m220514_224351_create_tai_treasure_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220514_224351_create_tai_treasure_trigger
+ */
+class m220514_224351_create_tai_treasure_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tai_treasure}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tai_treasure}} AFTER INSERT ON {{%treasure}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    UPDATE target_state SET total_treasures=total_treasures+1,total_points=total_points+ifnull(NEW.points,0),treasure_points=treasure_points+ifnull(NEW.points,0) WHERE id=NEW.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220514_224355_create_tad_treasure_trigger.php
+++ b/backend/migrations/m220514_224355_create_tad_treasure_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220514_224355_create_tad_treasure_trigger
+ */
+class m220514_224355_create_tad_treasure_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_treasure}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_treasure}} AFTER DELETE ON {{%treasure}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    UPDATE target_state SET total_treasures=total_treasures-1,total_points=total_points-IFNULL(OLD.points,0),treasure_points=treasure_points-IFNULL(OLD.points,0) WHERE id=OLD.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220514_225608_update_tai_finding_trigger_add_target_state.php
+++ b/backend/migrations/m220514_225608_update_tai_finding_trigger_add_target_state.php
@@ -1,0 +1,33 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220514_225608_update_tai_finding_trigger_add_target_state
+ */
+class m220514_225608_update_tai_finding_trigger_add_target_state extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tai_finding}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tai_finding}} AFTER INSERT ON {{%finding}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    IF (select memc_server_count()<1) THEN
+        select memc_servers_set('127.0.0.1') INTO @memc_server_set_status;
+    END IF;
+    DO memc_set(CONCAT('finding:',NEW.protocol,':',ifnull(NEW.port,0), ':', NEW.target_id ),NEW.id);
+    UPDATE target_state SET total_findings=total_findings+1,total_points=total_points+IFNULL(NEW.points,0),finding_points=finding_points+IFNULL(NEW.points,0) WHERE id=NEW.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220514_225643_update_tad_finding_trigger_add_target_state.php
+++ b/backend/migrations/m220514_225643_update_tad_finding_trigger_add_target_state.php
@@ -1,0 +1,34 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220514_225643_update_tad_finding_trigger_add_target_state
+ */
+class m220514_225643_update_tad_finding_trigger_add_target_state extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_finding}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_finding}} AFTER DELETE ON {{%finding}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    IF (select memc_server_count()<1) THEN
+        select memc_servers_set('127.0.0.1') INTO @memc_server_set_status;
+    END IF;
+    DO memc_delete(CONCAT('finding:',OLD.protocol,':',ifnull(OLD.port,0), ':', OLD.target_id ));
+
+    UPDATE target_state SET total_findings=total_findings-1,total_points=total_points-IFNULL(OLD.points,0),finding_points=finding_points-IFNULL(OLD.points,0) WHERE id=OLD.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220514_230150_update_tai_headshot_trigger_add_target_state.php
+++ b/backend/migrations/m220514_230150_update_tai_headshot_trigger_add_target_state.php
@@ -16,7 +16,7 @@ class m220514_230150_update_tai_headshot_trigger_add_target_state extends Migrat
     IF (SELECT headshot_spin FROM target WHERE id=NEW.target_id)>0 THEN
       INSERT IGNORE INTO spin_queue (target_id, player_id,created_at) VALUES (NEW.target_id,NEW.player_id,NOW());
     END IF;
-    UPDATE target_state SET total_headshots=total_headshots+1,timer_avg=timer_avg+ifnull(NEW.timer,0) WHERE id=NEW.target_id;
+    UPDATE target_state SET total_headshots=total_headshots+1,timer_avg=(SELECT round(avg(timer)) FROM headshot WHERE target_id=NEW.target_id) WHERE id=NEW.target_id;
     END";
 
     public function up()

--- a/backend/migrations/m220514_230150_update_tai_headshot_trigger_add_target_state.php
+++ b/backend/migrations/m220514_230150_update_tai_headshot_trigger_add_target_state.php
@@ -1,0 +1,32 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220514_230150_update_tai_headshot_trigger_add_target_state
+ */
+class m220514_230150_update_tai_headshot_trigger_add_target_state extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tai_headshot}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tai_headshot}} AFTER INSERT ON {{%headshot}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    IF (SELECT headshot_spin FROM target WHERE id=NEW.target_id)>0 THEN
+      INSERT IGNORE INTO spin_queue (target_id, player_id,created_at) VALUES (NEW.target_id,NEW.player_id,NOW());
+    END IF;
+    UPDATE target_state SET total_headshots=total_headshots+1,timer_avg=timer_avg+ifnull(NEW.timer,0) WHERE id=NEW.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220514_230211_update_tad_headshot_trigger_add_target_state.php
+++ b/backend/migrations/m220514_230211_update_tad_headshot_trigger_add_target_state.php
@@ -13,7 +13,7 @@ class m220514_230211_update_tad_headshot_trigger_add_target_state extends Migrat
     IF (@TRIGGER_CHECKS = FALSE) THEN
         LEAVE thisBegin;
     END IF;
-    UPDATE target_state SET total_headshots=total_headshots-1,timer_avg=timer_avg-ifnull(OLD.timer,0) WHERE id=OLD.target_id;
+    UPDATE target_state SET total_headshots=total_headshots-1,timer_avg=(SELECT round(avg(timer)) FROM headshot WHERE target_id=OLD.target_id) WHERE id=OLD.target_id;
     END";
 
     public function up()

--- a/backend/migrations/m220514_230211_update_tad_headshot_trigger_add_target_state.php
+++ b/backend/migrations/m220514_230211_update_tad_headshot_trigger_add_target_state.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220514_230211_update_tad_headshot_trigger_add_target_state
+ */
+class m220514_230211_update_tad_headshot_trigger_add_target_state extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_headshot}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_headshot}} AFTER DELETE ON {{%headshot}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    UPDATE target_state SET total_headshots=total_headshots-1,timer_avg=timer_avg-ifnull(OLD.timer,0) WHERE id=OLD.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_001506_create_tai_writeup_trigger.php
+++ b/backend/migrations/m220515_001506_create_tai_writeup_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_001506_create_tai_writeup_trigger
+ */
+class m220515_001506_create_tai_writeup_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tai_writeup}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tai_writeup}} AFTER INSERT ON {{%writeup}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    UPDATE target_state SET total_writeups=total_writeups+1 WHERE id=NEW.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_003413_create_tau_writeup_trigger.php
+++ b/backend/migrations/m220515_003413_create_tau_writeup_trigger.php
@@ -1,0 +1,35 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_003413_create_tau_writeup_trigger
+ */
+class m220515_003413_create_tau_writeup_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tau_writeup}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tau_writeup}} AFTER UPDATE ON {{%writeup}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+
+    IF NEW.approved=1 and OLD.approved=0 THEN
+       UPDATE target_state SET approved_writeups=approved_writeups+1 WHERE id=NEW.target_id;
+    ELSEIF NEW.approved=0 and OLD.approved=1 THEN
+       UPDATE target_state SET approved_writeups=approved_writeups-1 WHERE id=NEW.target_id;
+    END IF;
+
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_003818_create_tad_writeup_trigger.php
+++ b/backend/migrations/m220515_003818_create_tad_writeup_trigger.php
@@ -1,0 +1,35 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_003818_create_tad_writeup_trigger
+ */
+class m220515_003818_create_tad_writeup_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_writeup}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_writeup}} AFTER DELETE ON {{%writeup}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+
+    IF OLD.approved=1 THEN
+       UPDATE target_state SET approved_writeups=approved_writeups-1,total_writeups=total_writeups-1 WHERE id=OLD.target_id;
+    ELSEIF OLD.approved=0 THEN
+       UPDATE target_state SET total_writeups=total_writeups-1 WHERE id=OLD.target_id;
+    END IF;
+
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_004033_create_tau_headshot_trigger.php
+++ b/backend/migrations/m220515_004033_create_tau_headshot_trigger.php
@@ -1,0 +1,32 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_004033_create_tau_headshot_trigger
+ */
+class m220515_004033_create_tau_headshot_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tau_headshot}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tau_headshot}} AFTER UPDATE ON {{%headshot}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    IF (OLD.rating IS NULL AND NEW.rating IS NOT NULL) OR (OLD.rating IS NOT NULL and NEW.rating!=OLD.rating) THEN
+      UPDATE target_state SET player_rating=(SELECT round(avg(rating)) FROM headshot WHERE target_id=NEW.target_id AND rating>-1) WHERE id=NEW.target_id;
+    END IF;
+
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_124225_create_tai_network_target_trigger.php
+++ b/backend/migrations/m220515_124225_create_tai_network_target_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_124225_create_tai_network_target_trigger
+ */
+class m220515_124225_create_tai_network_target_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tai_network_target}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tai_network_target}} AFTER INSERT ON {{%network_target}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    UPDATE target_state SET on_network=1 WHERE id=NEW.target_id and on_network!=1;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_124231_create_tad_network_target_trigger.php
+++ b/backend/migrations/m220515_124231_create_tad_network_target_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_124231_create_tad_network_target_trigger
+ */
+class m220515_124231_create_tad_network_target_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_network_target}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_network_target}} AFTER DELETE ON {{%network_target}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    UPDATE target_state SET on_network=(select 1 from network_target where target_id=OLD.target_id) WHERE id=OLD.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_124637_create_tai_target_ondemand_trigger.php
+++ b/backend/migrations/m220515_124637_create_tai_target_ondemand_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_124637_create_tai_target_ondemand_trigger
+ */
+class m220515_124637_create_tai_target_ondemand_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tai_target_ondemand}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tai_target_ondemand}} AFTER INSERT ON {{%target_ondemand}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    UPDATE target_state SET on_ondemand=1,ondemand_state=NEW.state WHERE id=NEW.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_124644_create_tad_target_ondemand_trigger.php
+++ b/backend/migrations/m220515_124644_create_tad_target_ondemand_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_124644_create_tad_target_ondemand_trigger
+ */
+class m220515_124644_create_tad_target_ondemand_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_target_ondemand}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_target_ondemand}} AFTER DELETE ON {{%target_ondemand}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    UPDATE target_state SET on_ondemand=0,ondemand_state=-1 WHERE id=OLD.target_id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_124707_create_tau_target_ondemand_trigger.php
+++ b/backend/migrations/m220515_124707_create_tau_target_ondemand_trigger.php
@@ -1,0 +1,31 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_124707_create_tau_target_ondemand_trigger
+ */
+class m220515_124707_create_tau_target_ondemand_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tau_target_ondemand}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tau_target_ondemand}} AFTER UPDATE ON {{%target_ondemand}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+
+    UPDATE target_state SET ondemand_state=NEW.state WHERE id=NEW.target_id;
+
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_203039_create_target_player_state_table.php
+++ b/backend/migrations/m220515_203039_create_target_player_state_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%target_player_state}}`.
+ */
+class m220515_203039_create_target_player_state_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->createTable('{{%target_player_state}}', [
+            'id' => $this->integer()->notNull(),
+            'player_id' => $this->integer()->unsigned()->notNull(),
+            'player_treasures' => $this->integer()->notNull()->defaultValue(0),
+            'player_findings'=> $this->integer()->notNull()->defaultValue(0),
+            'player_points'=> $this->integer()->notNull()->defaultValue(0),
+            'PRIMARY KEY (id,player_id)',
+        ]);
+
+        // add foreign key for table `{{%player}}`
+        $this->addForeignKey(
+            '{{%fk-target_player_state-id}}',
+            '{{%target_player_state}}',
+            'id',
+            '{{%target}}',
+            'id',
+            'CASCADE'
+        );
+        // add foreign key for table `{{%player}}`
+        $this->addForeignKey(
+            '{{%fk-target_player_state-player_id}}',
+            '{{%target_player_state}}',
+            'player_id',
+            '{{%player}}',
+            'id',
+            'CASCADE'
+        );
+
+        $this->createIndex(
+            'idx-target_player_state-player_treasures',
+            'target_player_state',
+            'player_treasures'
+        );
+        $this->createIndex(
+            'idx-target_player_state-player_findings',
+            'target_player_state',
+            'player_findings'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropTable('{{%target_player_state}}');
+    }
+}

--- a/backend/migrations/m220515_203600_populate_target_player_state_with_data.php
+++ b/backend/migrations/m220515_203600_populate_target_player_state_with_data.php
@@ -1,0 +1,27 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_203600_populate_target_player_state_with_data
+ */
+class m220515_203600_populate_target_player_state_with_data extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->db->createCommand("INSERT INTO target_player_state (id,player_id,player_points,player_treasures) select target_id,player_id,sum(t1.points),count(*) from player_treasure as t1 left join treasure as t2 on t1.treasure_id=t2.id group by target_id,player_id")->execute();
+        $this->db->createCommand("INSERT INTO target_player_state (id,player_id,player_points,player_findings) select target_id,player_id,sum(t1.points),count(*) from player_finding as t1 left join finding as t2 on t1.finding_id=t2.id group by target_id,player_id ON DUPLICATE KEY UPDATE player_findings=values(player_findings),player_points=player_points+values(player_points)")->execute();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        echo "m220515_203600_populate_target_player_state_with_data cannot be reverted.\n";
+
+    }
+}

--- a/backend/migrations/m220515_204708_update_tai_player_treasure_trigger.php
+++ b/backend/migrations/m220515_204708_update_tai_player_treasure_trigger.php
@@ -1,0 +1,47 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_204708_update_tai_player_treasure_trigger
+ */
+class m220515_204708_update_tai_player_treasure_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tai_player_treasure}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tai_player_treasure}} AFTER INSERT ON {{%player_treasure}} FOR EACH ROW
+    thisBegin:BEGIN
+    DECLARE local_target_id INT;
+    DECLARE headshoted INT default null;
+    DECLARE min_finding,min_treasure,max_finding,max_treasure, max_val, min_val DATETIME;
+
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+      LEAVE thisBegin;
+    END IF;
+
+    CALL add_treasure_stream(NEW.player_id,'treasure',NEW.treasure_id,NEW.points);
+    CALL add_player_treasure_hint(NEW.player_id,NEW.treasure_id);
+
+    SET local_target_id=(SELECT target_id FROM treasure WHERE id=NEW.treasure_id);
+    SET headshoted=(select true as headshoted FROM target as t left join treasure as t2 on t2.target_id=t.id left join finding as t3 on t3.target_id=t.id LEFT JOIN player_treasure as t4 on t4.treasure_id=t2.id and t4.player_id=NEW.player_id left join player_finding as t5 on t5.finding_id=t3.id and t5.player_id=NEW.player_id WHERE t.id=local_target_id   GROUP BY t.id HAVING count(distinct t2.id)=count(distinct t4.treasure_id) AND count(distinct t3.id)=count(distinct t5.finding_id));
+
+    IF headshoted IS NOT NULL THEN
+        SELECT min(ts),max(ts) INTO min_finding,max_finding FROM player_finding WHERE player_id=NEW.player_id AND finding_id IN (SELECT id FROM finding WHERE target_id=local_target_id);
+        SELECT min(ts),max(ts) INTO min_treasure,max_treasure FROM player_treasure WHERE player_id=NEW.player_id AND treasure_id IN (SELECT id FROM treasure WHERE target_id=local_target_id);
+        SELECT GREATEST(max_finding, max_treasure), LEAST(min_finding, min_treasure) INTO max_val,min_val;
+        INSERT INTO headshot (player_id,target_id,created_at,timer) VALUES (NEW.player_id,local_target_id,now(),UNIX_TIMESTAMP(max_val)-UNIX_TIMESTAMP(min_val));
+        INSERT INTO stream (player_id,model,model_id,points,title,message,pubtitle,pubmessage,ts) VALUES (NEW.player_id,'headshot',local_target_id,0,'','','','',now());
+    END IF;
+    INSERT INTO target_player_state (id,player_id,player_treasures,player_points) VALUES (local_target_id,NEW.player_id,1,NEW.points) ON DUPLICATE KEY UPDATE player_treasures=player_treasures+values(player_treasures),player_points=player_points+values(player_points);
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m220515_205422_update_tai_player_finding_trigger.php
+++ b/backend/migrations/m220515_205422_update_tai_player_finding_trigger.php
@@ -1,0 +1,51 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m220515_205422_update_tai_player_finding_trigger
+ */
+class m220515_205422_update_tai_player_finding_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tai_player_finding}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tai_player_finding}} AFTER INSERT ON {{%player_finding}} FOR EACH ROW
+    thisBegin:BEGIN
+    DECLARE local_target_id INT;
+    DECLARE headshoted INT default null;
+    DECLARE min_finding,min_treasure,max_finding,max_treasure, max_val, min_val DATETIME;
+
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+      LEAVE thisBegin;
+    END IF;
+
+    IF (select memc_server_count()<1) THEN
+      select memc_servers_set('127.0.0.1') INTO @memc_server_set_status;
+    END IF;
+    SELECT memc_set(CONCAT('player_finding:',NEW.player_id, ':', NEW.finding_id),NEW.player_id) INTO @devnull;
+
+    CALL add_finding_stream(NEW.player_id,'finding',NEW.finding_id,NEW.points);
+    CALL add_player_finding_hint(NEW.player_id,NEW.finding_id);
+
+    SET local_target_id=(SELECT target_id FROM finding WHERE id=NEW.finding_id);
+    SET headshoted=(select true as headshoted FROM target as t left join treasure as t2 on t2.target_id=t.id left join finding as t3 on t3.target_id=t.id LEFT JOIN player_treasure as t4 on t4.treasure_id=t2.id and t4.player_id=NEW.player_id left join player_finding as t5 on t5.finding_id=t3.id and t5.player_id=NEW.player_id WHERE t.id=local_target_id   GROUP BY t.id HAVING count(distinct t2.id)=count(distinct t4.treasure_id) AND count(distinct t3.id)=count(distinct t5.finding_id));
+    IF headshoted IS NOT NULL THEN
+      SELECT min(ts),max(ts) INTO min_finding,max_finding FROM player_finding WHERE player_id=NEW.player_id AND finding_id IN (SELECT id FROM finding WHERE target_id=local_target_id);
+      SELECT min(ts),max(ts) INTO min_treasure,max_treasure FROM player_treasure WHERE player_id=NEW.player_id AND treasure_id IN (SELECT id FROM treasure WHERE target_id=local_target_id);
+      SELECT GREATEST(max_finding, max_treasure), LEAST(min_finding, min_treasure) INTO max_val,min_val;
+      INSERT INTO headshot (player_id,target_id,created_at,timer) VALUES (NEW.player_id,local_target_id,now(),UNIX_TIMESTAMP(max_val)-UNIX_TIMESTAMP(min_val));
+      INSERT INTO stream (player_id,model,model_id,points,title,message,pubtitle,pubmessage,ts) VALUES (NEW.player_id,'headshot',local_target_id,0,'','','','',now());
+    END IF;
+    INSERT INTO target_player_state (id,player_id,player_findings,player_points) VALUES (local_target_id,NEW.player_id,1,NEW.points) ON DUPLICATE KEY UPDATE player_findings=player_findings+values(player_findings),player_points=player_points+values(player_points);
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/modules/gameplay/views/treasure/_form.php
+++ b/backend/modules/gameplay/views/treasure/_form.php
@@ -14,8 +14,8 @@ use app\modules\gameplay\models\Target;
 
     <?php $form=ActiveForm::begin();?>
 
-    <?= $form->field($model, 'target_id')->dropDownList(ArrayHelper::map(Target::find()->all(), 'id', function($model) {
-        return sprintf("(id:%d) %s/%s", $model['id'], $model['fqdn'], $model['ipoctet']);}), ['prompt'=>'Select the target'])->Label('Target') ?>
+    <?= $form->field($model, 'target_id')->dropDownList(ArrayHelper::map(Target::find()->orderBy(['name'=>SORT_ASC])->all(), 'id', function($model) {
+        return sprintf("%s/%s", $model['fqdn'], $model['ipoctet']);}), ['prompt'=>'Select the target'])->Label('Target') ?>
 
     <?= $form->field($model, 'name')->textInput(['maxlength' => true])->hint('A name for the treasure') ?>
 

--- a/backend/modules/gameplay/views/treasure/index.php
+++ b/backend/modules/gameplay/views/treasure/index.php
@@ -61,7 +61,8 @@ yii\bootstrap\Modal::end();
 
             [
               'attribute'=>'code',
-              'value'=>function($model) {return substr($model->code, 0, 15);},
+              'format'=>'raw',
+              'value'=>function($model) {return '<abbr title="'.Html::encode($model->code).'">'.substr($model->code, 0, 15).'</abbr>';},
             ],
 
             [

--- a/frontend/modules/network/controllers/DefaultController.php
+++ b/frontend/modules/network/controllers/DefaultController.php
@@ -79,18 +79,22 @@ class DefaultController extends \app\components\BaseController
             'attributes' => array_merge(
                 $targetProgressProvider->getSort()->attributes,
                 [
-                  'total_findings' => [
-                      'asc' => ['total_findings' => SORT_ASC],
-                      'desc' => ['total_findings' => SORT_DESC],
-                  ],
-                  'total_treasures' => [
-                    'asc' => ['total_treasures' => SORT_ASC],
-                    'desc' => ['total_treasures' => SORT_DESC],
-                  ],
-                  'headshots' => [
-                    'asc' => ['total_headshots' => SORT_ASC],
-                    'desc' => ['total_headshots' => SORT_DESC],
-                  ],
+                    'headshots' => [
+                      'asc' => ['total_headshots'=>SORT_ASC],
+                      'desc' => ['total_headshots'=>SORT_DESC],
+                    ],
+                    'total_findings' => [
+                      'asc' => ['total_findings'=>SORT_ASC],
+                      'desc' => ['total_findings'=>SORT_DESC],
+                    ],
+                    'total_treasures' => [
+                      'asc' => ['total_treasures'=>SORT_ASC],
+                      'desc' => ['total_treasures'=>SORT_DESC],
+                    ],
+                    'progress'=>[
+                      'asc'=>['(player_points/total_points)*100'=>SORT_ASC],
+                      'desc'=>['(player_points/total_points)*100'=>SORT_DESC],
+                    ]
                 ]
             ),
         ]);

--- a/frontend/modules/target/models/TargetAR.php
+++ b/frontend/modules/target/models/TargetAR.php
@@ -64,6 +64,8 @@ class TargetAR extends \yii\db\ActiveRecord
   public $player_rating;
   public $ipoctet;
   public $progress;
+  public $on_ondemand;
+  public $ondemand_state;
 
     /**
      * {@inheritdoc}
@@ -98,6 +100,8 @@ class TargetAR extends \yii\db\ActiveRecord
             'headshot_spin'=> AttributeTypecastBehavior::TYPE_BOOLEAN,
             'difficulty' => AttributeTypecastBehavior::TYPE_INTEGER,
             'weight' => AttributeTypecastBehavior::TYPE_INTEGER,
+            'on_ondemand' => AttributeTypecastBehavior::TYPE_BOOLEAN,
+            'ondemand_state' => AttributeTypecastBehavior::TYPE_INTEGER,
           ],
           'typecastAfterValidate' => true,
           'typecastBeforeSave' => true,

--- a/frontend/modules/target/models/TargetAR.php
+++ b/frontend/modules/target/models/TargetAR.php
@@ -66,6 +66,7 @@ class TargetAR extends \yii\db\ActiveRecord
   public $progress;
   public $on_ondemand;
   public $ondemand_state;
+  public $timer_avg;
 
     /**
      * {@inheritdoc}
@@ -102,6 +103,7 @@ class TargetAR extends \yii\db\ActiveRecord
             'weight' => AttributeTypecastBehavior::TYPE_INTEGER,
             'on_ondemand' => AttributeTypecastBehavior::TYPE_BOOLEAN,
             'ondemand_state' => AttributeTypecastBehavior::TYPE_INTEGER,
+            'timer_avg'=> AttributeTypecastBehavior::TYPE_INTEGER,
           ],
           'typecastAfterValidate' => true,
           'typecastBeforeSave' => true,

--- a/frontend/modules/target/models/TargetQuery.php
+++ b/frontend/modules/target/models/TargetQuery.php
@@ -18,29 +18,10 @@ class TargetQuery extends \yii\db\ActiveQuery
       {
         return $this->andWhere(['active' => 1]);
       }
-      public function forWidgets()
-      {
-        return $this->select(['t.id,t.ip,t.difficulty,t.rootable, count(distinct treasure.id) as total_treasures, count(distinct finding.id) as total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress']);
-      }
+
       public function not_in_network()
       {
-        return $this->andWhere(['on_network'=>1]);
-//        return $this->andWhere('t.id not in (select target_id from network_target)');
-      }
-      public function forListing($player_id)
-      {
-        $this->alias('t');
-        $this->select(['t.id, t.name,t.status,t.ip,difficulty, rootable,scheduled_at,t.ts, count(distinct treasure.id) as total_treasures, count(distinct finding.id) as total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress, avg(headshot.rating) as player_rating,count(distinct headshot.player_id) as total_headshots, count(distinct writeup.id) as total_writeups,count(distinct (case when writeup.approved=1 then writeup.id end)) as approved_writeups']);
-        $this->join('LEFT JOIN', 'treasure', 'treasure.target_id=t.id');
-        $this->join('LEFT JOIN', 'finding', 'finding.target_id=t.id');
-        $this->join('LEFT JOIN', 'player_treasure', 'player_treasure.treasure_id=treasure.id and player_treasure.player_id='.$player_id);
-        $this->join('LEFT JOIN', 'player_finding', 'player_finding.finding_id=finding.id and player_finding.player_id='.$player_id);
-        $this->join('LEFT JOIN', 'headshot', 'headshot.target_id=t.id');
-        $this->join('LEFT JOIN', 'writeup', 'writeup.target_id=t.id');
-        //$this->andWhere(['>','headshot.rating',-1]);
-        $this->groupBy('t.id');
-        return $this;
-
+        return $this->andWhere(['on_network'=>0]);
       }
 
       public function forView($player_id)
@@ -53,39 +34,22 @@ class TargetQuery extends \yii\db\ActiveQuery
         $this->join('LEFT JOIN', 'player_finding', 'player_finding.finding_id=finding.id and player_finding.player_id='.intval($player_id));
         $this->join('LEFT JOIN', 'headshot', 'headshot.target_id=t.id');
         $this->join('LEFT JOIN', 'writeup', 'writeup.target_id=t.id');
-        //$this->andWhere(['>','headshot.rating',-1]);
         $this->groupBy('t.id');
         return $this;
       }
-      //public function player_progress($player_id=0)
-      //{
-      //  $this->alias('t');
-      //  $this->select(['t.id, t.name,t.status,t.active, t.ip,difficulty, rootable,scheduled_at,t.ts, count(distinct treasure.id) as total_treasures, count(distinct finding.id) as total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress, avg(CASE WHEN headshot.rating > -1 THEN headshot.rating END) as player_rating,count(distinct headshot.player_id) as total_headshots, count(distinct writeup.id) as total_writeups,count(distinct (case when writeup.approved=1 then writeup.id end)) as approved_writeups']);
-      //  $this->join('LEFT JOIN', 'treasure', 'treasure.target_id=t.id');
-      //  $this->join('LEFT JOIN', 'finding', 'finding.target_id=t.id');
-      //  $this->join('LEFT JOIN', 'player_treasure', 'player_treasure.treasure_id=treasure.id and player_treasure.player_id='.intval($player_id));
-      //  $this->join('LEFT JOIN', 'player_finding', 'player_finding.finding_id=finding.id and player_finding.player_id='.intval($player_id));
-      //  $this->join('LEFT JOIN', 'headshot', 'headshot.target_id=t.id');
-      //  $this->join('LEFT JOIN', 'writeup', 'writeup.target_id=t.id');
-      //  //$this->andWhere(['>','headshot.rating',-1]);
-      //  $this->groupBy('t.id');
-      //  //die(var_dump($this->createCommand()->rawSql));
-      //  return $this;
-      //}
 
       public function player_progress($player_id=0)
       {
         $this->alias('t');
         $this->select(['t.id', 't.name', 't.status', 't.active', 't.ip', 't.difficulty', 'rootable','t.scheduled_at','t.ts']);
+        $this->addSelect(['on_ondemand','ondemand_state']);
         $this->addSelect('total_treasures, total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress, player_rating, total_headshots, total_writeups, approved_writeups');
         $this->join('LEFT JOIN', 'target_state', 'target_state.id=t.id');
         $this->join('LEFT JOIN', 'treasure', 'treasure.target_id=t.id');
         $this->join('LEFT JOIN', 'finding', 'finding.target_id=t.id');
         $this->join('LEFT JOIN', 'player_treasure', 'player_treasure.treasure_id=treasure.id and player_treasure.player_id='.intval($player_id));
         $this->join('LEFT JOIN', 'player_finding', 'player_finding.finding_id=finding.id and player_finding.player_id='.intval($player_id));
-        //$this->andWhere(['>','headshot.rating',-1]);
         $this->groupBy('t.id');
-//        die(var_dump($this->createCommand()->rawSql));
         return $this;
       }
 

--- a/frontend/modules/target/models/TargetQuery.php
+++ b/frontend/modules/target/models/TargetQuery.php
@@ -24,7 +24,8 @@ class TargetQuery extends \yii\db\ActiveQuery
       }
       public function not_in_network()
       {
-        return $this->andWhere('t.id not in (select target_id from network_target)');
+        return $this->andWhere(['on_network'=>1]);
+//        return $this->andWhere('t.id not in (select target_id from network_target)');
       }
       public function forListing($player_id)
       {

--- a/frontend/modules/target/models/TargetQuery.php
+++ b/frontend/modules/target/models/TargetQuery.php
@@ -5,11 +5,6 @@ use Yii;
 
 class TargetQuery extends \yii\db\ActiveQuery
 {
-/*      public function init()
-      {
-          $this->andOnCondition([$this->modelClass::tableName() . '.branch_id' => Yii::$app->user->identity->branch_id ]);
-          parent::init();
-      }*/
       public function forNet(int $network_id)
       {
         return $this->join('LEFT JOIN','network_target','network_target.target_id=t.id')->andWhere(['network_target.network_id'=>$network_id]);
@@ -61,18 +56,35 @@ class TargetQuery extends \yii\db\ActiveQuery
         $this->groupBy('t.id');
         return $this;
       }
+      //public function player_progress($player_id=0)
+      //{
+      //  $this->alias('t');
+      //  $this->select(['t.id, t.name,t.status,t.active, t.ip,difficulty, rootable,scheduled_at,t.ts, count(distinct treasure.id) as total_treasures, count(distinct finding.id) as total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress, avg(CASE WHEN headshot.rating > -1 THEN headshot.rating END) as player_rating,count(distinct headshot.player_id) as total_headshots, count(distinct writeup.id) as total_writeups,count(distinct (case when writeup.approved=1 then writeup.id end)) as approved_writeups']);
+      //  $this->join('LEFT JOIN', 'treasure', 'treasure.target_id=t.id');
+      //  $this->join('LEFT JOIN', 'finding', 'finding.target_id=t.id');
+      //  $this->join('LEFT JOIN', 'player_treasure', 'player_treasure.treasure_id=treasure.id and player_treasure.player_id='.intval($player_id));
+      //  $this->join('LEFT JOIN', 'player_finding', 'player_finding.finding_id=finding.id and player_finding.player_id='.intval($player_id));
+      //  $this->join('LEFT JOIN', 'headshot', 'headshot.target_id=t.id');
+      //  $this->join('LEFT JOIN', 'writeup', 'writeup.target_id=t.id');
+      //  //$this->andWhere(['>','headshot.rating',-1]);
+      //  $this->groupBy('t.id');
+      //  //die(var_dump($this->createCommand()->rawSql));
+      //  return $this;
+      //}
+
       public function player_progress($player_id=0)
       {
         $this->alias('t');
-        $this->select(['t.id, t.name,t.status,t.active, t.ip,difficulty, rootable,scheduled_at,t.ts, count(distinct treasure.id) as total_treasures, count(distinct finding.id) as total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress, avg(CASE WHEN headshot.rating > -1 THEN headshot.rating END) as player_rating,count(distinct headshot.player_id) as total_headshots, count(distinct writeup.id) as total_writeups,count(distinct (case when writeup.approved=1 then writeup.id end)) as approved_writeups']);
+        $this->select(['t.id', 't.name', 't.status', 't.active', 't.ip', 't.difficulty', 'rootable','t.scheduled_at','t.ts']);
+        $this->addSelect('total_treasures, total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress, player_rating, total_headshots, total_writeups, approved_writeups');
+        $this->join('LEFT JOIN', 'target_state', 'target_state.id=t.id');
         $this->join('LEFT JOIN', 'treasure', 'treasure.target_id=t.id');
         $this->join('LEFT JOIN', 'finding', 'finding.target_id=t.id');
         $this->join('LEFT JOIN', 'player_treasure', 'player_treasure.treasure_id=treasure.id and player_treasure.player_id='.intval($player_id));
         $this->join('LEFT JOIN', 'player_finding', 'player_finding.finding_id=finding.id and player_finding.player_id='.intval($player_id));
-        $this->join('LEFT JOIN', 'headshot', 'headshot.target_id=t.id');
-        $this->join('LEFT JOIN', 'writeup', 'writeup.target_id=t.id');
         //$this->andWhere(['>','headshot.rating',-1]);
         $this->groupBy('t.id');
+//        die(var_dump($this->createCommand()->rawSql));
         return $this;
       }
 

--- a/frontend/modules/target/models/TargetQuery.php
+++ b/frontend/modules/target/models/TargetQuery.php
@@ -27,14 +27,11 @@ class TargetQuery extends \yii\db\ActiveQuery
       public function forView($player_id)
       {
         $this->alias('t');
-        $this->select(['t.*, count(distinct treasure.id) as total_treasures, count(distinct finding.id) as total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress, avg(CASE WHEN headshot.rating > -1 THEN headshot.rating END) as player_rating,count(distinct headshot.player_id) as total_headshots, count(distinct writeup.id) as total_writeups,count(distinct (case when writeup.approved=1 then writeup.id end)) as approved_writeups']);
-        $this->join('LEFT JOIN', 'treasure', 'treasure.target_id=t.id');
-        $this->join('LEFT JOIN', 'finding', 'finding.target_id=t.id');
-        $this->join('LEFT JOIN', 'player_treasure', 'player_treasure.treasure_id=treasure.id and player_treasure.player_id='.intval($player_id));
-        $this->join('LEFT JOIN', 'player_finding', 'player_finding.finding_id=finding.id and player_finding.player_id='.intval($player_id));
-        $this->join('LEFT JOIN', 'headshot', 'headshot.target_id=t.id');
-        $this->join('LEFT JOIN', 'writeup', 'writeup.target_id=t.id');
-        $this->groupBy('t.id');
+        $this->select(['t.*']);
+        $this->addSelect(['on_ondemand','ondemand_state','timer_avg']);
+        $this->addSelect('total_treasures, total_findings, player_treasures, player_findings, (player_points/total_points)*100 as progress, player_rating, total_headshots, total_writeups, approved_writeups');
+        $this->join('LEFT JOIN', 'target_state', 'target_state.id=t.id');
+        $this->join('LEFT JOIN','target_player_state','target_player_state.id=t.id AND target_player_state.player_id='.intval($player_id));
         return $this;
       }
 
@@ -43,13 +40,9 @@ class TargetQuery extends \yii\db\ActiveQuery
         $this->alias('t');
         $this->select(['t.id', 't.name', 't.status', 't.active', 't.ip', 't.difficulty', 'rootable','t.scheduled_at','t.ts']);
         $this->addSelect(['on_ondemand','ondemand_state']);
-        $this->addSelect('total_treasures, total_findings,count(distinct player_treasure.treasure_id) as player_treasures,count(distinct player_finding.finding_id) as player_findings, (((count(distinct player_treasure.treasure_id)+count(distinct player_finding.finding_id))*100)/(count(distinct finding.id)+count(distinct treasure.id))) as progress, player_rating, total_headshots, total_writeups, approved_writeups');
+        $this->addSelect('total_treasures, total_findings, player_treasures, player_findings, (player_points/total_points)*100 as progress, player_rating, total_headshots, total_writeups, approved_writeups');
         $this->join('LEFT JOIN', 'target_state', 'target_state.id=t.id');
-        $this->join('LEFT JOIN', 'treasure', 'treasure.target_id=t.id');
-        $this->join('LEFT JOIN', 'finding', 'finding.target_id=t.id');
-        $this->join('LEFT JOIN', 'player_treasure', 'player_treasure.treasure_id=treasure.id and player_treasure.player_id='.intval($player_id));
-        $this->join('LEFT JOIN', 'player_finding', 'player_finding.finding_id=finding.id and player_finding.player_id='.intval($player_id));
-        $this->groupBy('t.id');
+        $this->join('LEFT JOIN','target_player_state','target_player_state.id=t.id AND target_player_state.player_id='.intval($player_id));
         return $this;
       }
 

--- a/frontend/themes/material/modules/target/views/default/_target_card.php
+++ b/frontend/themes/material/modules/target/views/default/_target_card.php
@@ -28,8 +28,7 @@ echo  "<small>(<code class='text-danger'>";
 echo $target->treasureCategoriesFormatted;
 echo "</code>)</small><br/>";
 echo "<i class='fas fa-fire'></i> ", $target->total_findings, ": Service".($target->total_findings > 1 ? 's' : '')."<br/><i class='fas fa-calculator'></i> ", number_format($target->points), " pts";
-$hs=Headshot::find()->target_avg_time($target->id)->one();
-if($hs && $hs->average > 0 && $target->timer!==0)
-  echo '<br/><i class="fas fa-stopwatch"></i> Avg. headshot: '.number_format($hs->average / 60).' minutes';
+if($target->timer!==0)
+  echo '<br/><i class="fas fa-stopwatch"></i> Avg. headshot: '.number_format($target->timer_avg / 60).' minutes';
 echo "</p>";
 Card::end();?>

--- a/frontend/widgets/target/TargetWidget.php
+++ b/frontend/widgets/target/TargetWidget.php
@@ -35,7 +35,7 @@ class TargetWidget extends Widget
     public $viewFile='target';
     public $hidden_attributes=[];
     public $buttonsTemplate="{view} {tweet}";
-    
+
     public function init()
     {
       if($this->dataProvider === null && $this->player_id === null)
@@ -112,21 +112,27 @@ class TargetWidget extends Widget
       $tmod=\app\modules\target\models\Target::find();
       if(intval($tmod->count()) === 0) return null;
 
-      foreach($tmod->all() as $model)
-      {
-        $orderByHeadshots[]=(object) ['id'=>$model->id, 'ip'=>$model->ip, 'headshots'=>$model->total_headshots];
-      }
-
-      ArrayHelper::multisort($orderByHeadshots, ['headshots', 'ip'], [SORT_ASC, SORT_ASC]);
-      $orderByHeadshotsASC=ArrayHelper::getColumn($orderByHeadshots, 'id');
-      ArrayHelper::multisort($orderByHeadshots, ['headshots', 'ip'], [SORT_DESC, SORT_ASC]);
-      $orderByHeadshotsDESC=ArrayHelper::getColumn($orderByHeadshots, 'id');
-
       $targetProgressProvider=$this->getTargetProgressProvider($tmod,$id,$defaultOrder);
       $targetProgressProvider->setSort([
           'sortParam'=>'target-sort',
-          'attributes' => $this->getOrderAttributes($orderByHeadshotsASC,$orderByHeadshotsDESC),
           'defaultOrder'=>$defaultOrder,
+          'attributes'=> array_merge(
+            $targetProgressProvider->getSort()->attributes,
+            [
+              'headshots' => [
+                'asc' => ['total_headshots'=>SORT_ASC],
+                'desc' => ['total_headshots'=>SORT_DESC],
+              ],
+              'total_findings' => [
+                'asc' => ['total_findings'=>SORT_ASC],
+                'desc' => ['total_findings'=>SORT_DESC],
+              ],
+              'total_treasures' => [
+                'asc' => ['total_treasures'=>SORT_ASC],
+                'desc' => ['total_treasures'=>SORT_DESC],
+              ],
+            ]
+          )
       ]);
 
       return $targetProgressProvider;

--- a/frontend/widgets/target/TargetWidget.php
+++ b/frontend/widgets/target/TargetWidget.php
@@ -131,6 +131,10 @@ class TargetWidget extends Widget
                 'asc' => ['total_treasures'=>SORT_ASC],
                 'desc' => ['total_treasures'=>SORT_DESC],
               ],
+              'progress'=>[
+                'asc'=>['(player_points/total_points)*100'=>SORT_ASC],
+                'desc'=>['(player_points/total_points)*100'=>SORT_DESC],
+              ]
             ]
           )
       ]);

--- a/frontend/widgets/target/views/target.php
+++ b/frontend/widgets/target/views/target.php
@@ -85,7 +85,8 @@ echo GridView::widget([
         'label'=>'IP',
         'headerOptions' => ["style"=>'width: 2vw;' /*, 'class'=>'d-none d-lg-table-cell'*/],
         'contentOptions'=> ["style"=>'width: 2vw;' /*, 'class'=>'d-none d-lg-table-cell'*/],
-        'value'=>function($model) {return long2ip($model->ip);}
+        'format'=>'raw',
+        'value'=>function($model) { if($model->on_ondemand && $model->ondemand_state===-1) return '<abbr title="System is powered down">0.0.0.0</abbr>'; else return long2ip($model->ip);}
       ],
       [
         'visible'=>!in_array('writeup', $hidden_attributes),


### PR DESCRIPTION
This PR brings the following
* Creates a flat table for target and player_target states, statuses and counters, the speed improvements are enormous (first response packet from 500ms=>20ms)
* Adds triggers to maintain the tables up to date
* Replaces target ip with 0.0.0.0 when on demand and powered down
* improve overall targetQuery for frontend reducing its footprint and complexity