### PR TITLE
Fix profile average

### DIFF
--- a/frontend/themes/material/profile/_headshot_item.php
+++ b/frontend/themes/material/profile/_headshot_item.php
@@ -17,7 +17,7 @@ use yii\helpers\Url;
                   ]
               );?></b></p>
     <p><b><i class="far fa-calendar-alt text-warning"></i> <?=\Yii::$app->formatter->asDate($model->created_at,'long')?></b><br/>
-    <i class="fas fa-stopwatch text-danger"></i> <?=\Yii::$app->formatter->asDuration($model->timer)?>
+    <?php if($model->timer>0):?><i class="fas fa-stopwatch text-danger"></i> <?=\Yii::$app->formatter->asDuration($model->timer)?><?php endif;?>
     </p>
   </div>
 </div>

--- a/frontend/themes/material/profile/_headshots.php
+++ b/frontend/themes/material/profile/_headshots.php
@@ -3,10 +3,10 @@ use yii\helpers\Html;
 use yii\helpers\Url;
 use yii\widgets\ListView;
 ?>
-<h3><code><?=$profile->headshotsCount?></code> Headshots / <small>Average time: <?php
+<h3><code><?=$profile->headshotsCount?></code> Headshots <?php
 $hs=\app\modules\game\models\Headshot::find()->timed()->player_avg_time($profile->player_id)->one();
 if($hs && $hs->average > 0)
-  echo number_format($hs->average / 60), " minutes";
+  echo "/ <small>Average time: ",number_format($hs->average / 60), " minutes";
 ?> <sub>(ordered by date)</small></sub></h3>
 <?php
 \yii\widgets\Pjax::begin(['id'=>'headshotslist', 'enablePushState'=>false, 'linkSelector'=>'#headshots-pager a', 'formSelector'=>false]);


### PR DESCRIPTION
This PR fixes 
* the average text being displayed when there is no average
* the headshot timer line when timer is 0

This was reported by @fmarasoglou :pray:
![image](https://user-images.githubusercontent.com/4373752/172367147-6a31e00d-ad4c-4f6c-b890-5632187abadf.png)

![unknown](https://user-images.githubusercontent.com/4373752/172367081-f87dc125-a6c7-43c7-a40f-2e715d1c092e.png)
 