### PR TITLE
Routes local file caching

### DIFF
--- a/docs/console-commands/Generator.md
+++ b/docs/console-commands/Generator.md
@@ -39,3 +39,25 @@ Generate all available registered URL routes on the system for easier testing of
 Usage: `./frontend/yii generator/urls domain`
 
 * `domain` A domain to use by default to prefix the generated urls
+
+## routes($outfile="routes.php")
+Generate a local file with the URL routes for when the memcache becomes unavailable.
+
+Usage: `./frontend/yii generator/routes outfile`
+
+* `outfile` A file to store the routes into, defaults to `config/routes.php`
+
+
+## disabled-routes($outfile="disabled-routes.php")
+Generate a local file with the disabled URL routes for when the memcache becomes unavailable.
+
+Usage: `./frontend/yii generator/disabled-routes outfile`
+
+* `outfile` A file to store the routes into, defaults to `config/disabled-routes.php`
+
+## player-disabled-routes($outfile="disabled-routes.php")
+Generate a local file with the player specific disabled URL routes for when the memcache becomes unavailable.
+
+Usage: `./frontend/yii generator/player-disabled-routes outfile`
+
+* `outfile` A file to store the routes into, defaults to `config/player-disabled-routes.php`

--- a/frontend/commands/GeneratorController.php
+++ b/frontend/commands/GeneratorController.php
@@ -47,7 +47,7 @@ class GeneratorController extends Controller {
       $routes=\yii\helpers\Json::decode(\Yii::$app->sys->disabled_routes);
       foreach($routes as $entry)
       {
-        $lines[]=sprintf("  'route'=>'%s',",$entry['route']);
+        $lines[]=sprintf("  ['route'=>'%s'],",$entry['route']);
       }
       $content=sprintf("<?php\nreturn [\n%s\n];", implode("\n",$lines));
       $dirn=\Yii::getAlias("@app/config");

--- a/frontend/commands/GeneratorController.php
+++ b/frontend/commands/GeneratorController.php
@@ -10,6 +10,85 @@ use app\models\Stream;
 class GeneratorController extends Controller {
 
   /**
+   * Create a local file with the url routes from memcached
+   */
+  public function actionRoutes($outfile="routes.php")
+  {
+    if(\Yii::$app->sys->routes===false || \Yii::$app->sys->routes===null)
+      return;
+    try
+    {
+      $routes[]=['source'=>'', 'destination' => 'site/index'];
+      $routes[]=['source'=>'/','destination' => 'site/index'];
+      $routes=\yii\helpers\ArrayHelper::merge($routes,\yii\helpers\Json::decode(\Yii::$app->sys->routes));
+      foreach($routes as $entry)
+      {
+        $lines[]=sprintf("  '%s' => '%s',",$entry['source'],$entry['destination']);
+      }
+      $content=sprintf("<?php\nreturn [\n%s\n];", implode("\n",$lines));
+      $dirn=\Yii::getAlias("@app/config");
+      file_put_contents("{$dirn}/{$outfile}",$content);
+    }
+    catch (\Exception $e)
+    {
+      echo "Failed to generate {$outfile}\n",$e->getMessage(),"\n";
+    }
+  }
+
+  /**
+   * Create a local file with the disabled routes from memcached
+   */
+  public function actionDisabledRoutes($outfile="disabled-routes.php")
+  {
+    if(\Yii::$app->sys->disabled_routes===false || \Yii::$app->sys->disabled_routes===null)
+      return;
+    try
+    {
+      $routes=\yii\helpers\Json::decode(\Yii::$app->sys->disabled_routes);
+      foreach($routes as $entry)
+      {
+        $lines[]=sprintf("  'route'=>'%s',",$entry['route']);
+      }
+      $content=sprintf("<?php\nreturn [\n%s\n];", implode("\n",$lines));
+      $dirn=\Yii::getAlias("@app/config");
+      file_put_contents("{$dirn}/{$outfile}",$content);
+    }
+    catch (\Exception $e)
+    {
+      echo "Failed to generate {$outfile}\n",$e->getMessage(),"\n";
+    }
+  }
+
+  /**
+   * Create a local file with the player disabled routes from memcached
+   */
+  public function actionPlayerDisabledRoutes($outfile="player-disabled-routes.php")
+  {
+    if(\Yii::$app->sys->player_disabled_routes===false || \Yii::$app->sys->player_disabled_routes===null)
+      return;
+
+    try
+    {
+      $routes=\yii\helpers\Json::decode(\Yii::$app->sys->player_disabled_routes);
+      foreach($routes as $entry)
+      {
+        $lines[]=sprintf("  'route'=>'%s',",$entry['route']);
+      }
+      $content=sprintf("<?php\nreturn [\n%s\n];", implode("\n",$lines));
+      $dirn=\Yii::getAlias("@app/config");
+      file_put_contents("{$dirn}/{$outfile}",$content);
+    }
+    catch (\yii\base\InvalidArgumentException $e)
+    {
+      echo "JSON::decode failure: ".$e->getMessage(),"\n";
+    }
+    catch (\Exception $e)
+    {
+      echo "Failed to generate $outfile\n",$e->getMessage(),"\n";
+    }
+  }
+
+  /**
    * Generate local mail templates from database
    */
   public function actionEmailTemplates($interval=60)

--- a/frontend/components/DisabledRoute.php
+++ b/frontend/components/DisabledRoute.php
@@ -23,14 +23,52 @@ class DisabledRoute extends Component
   }
 
   /**
+   * Get the disabled_routes depending on memcached availability
+   * @return string
+   */
+  public static function disabled_routes()
+  {
+    if(Yii::$app->sys->disabled_routes!==false && Yii::$app->sys->disabled_routes!==null)
+    {
+      return Yii::$app->sys->disabled_routes;
+    }
+    $lrfile=\Yii::getAlias("@app/config/disabled-routes.php");
+    if(file_exists($lrfile))
+    {
+      $dr=include $lrfile;
+      return json_encode($dr,JSON_UNESCAPED_SLASHES);
+    }
+  }
+
+  /**
+   * Get the player_disabled_routes depending on memcached availability
+   * @return string
+   */
+  public static function player_disabled_routes()
+  {
+    if(Yii::$app->sys->player_disabled_routes!==false && Yii::$app->sys->player_disabled_routes!==null)
+    {
+      return Yii::$app->sys->player_disabled_routes;
+    }
+    $lrfile=\Yii::getAlias("@app/config/player_disabled-routes.php");
+    if(file_exists($lrfile))
+    {
+      $dr=include $lrfile;
+      return json_encode($dr,JSON_UNESCAPED_SLASHES);
+    }
+  }
+
+  /**
    * Check if current action is disabled
    * @param string|object $action
    * @return bool
    */
   public static function disabled($action):bool
   {
-    $disabled_routes=Yii::$app->sys->disabled_routes;
-    $player_disabled_routes=Yii::$app->sys->player_disabled_routes;
+
+    $disabled_routes=self::disabled_routes();
+    $player_disabled_routes=self::player_disabled_routes();
+
     if(is_object($action))
     {
       $route=self::RequestedRoute($action);

--- a/frontend/extensions/MemcacheUrlManagerBootstrap.php
+++ b/frontend/extensions/MemcacheUrlManagerBootstrap.php
@@ -24,5 +24,14 @@ class MemcacheUrlManagerBootstrap implements BootstrapInterface
           $oApplication->getUrlManager()->addRules($routes, false);
         }
       }
+      else // for some reason we failed to load the routes from memcached
+      {
+        $lrfile=\Yii::getAlias("@app/config/routes.php");
+        if(file_exists($lrfile))
+        {
+          $localroutes=include $lrfile;
+          $oApplication->getUrlManager()->addRules($localroutes, false);
+        }
+      }
     }
 }


### PR DESCRIPTION
This PR introduces
* [x] 3 frontend generator actions for producing local files with `routes`, `disabled_routes` and `player_disabled_routes` contents
* [x] Update our memcache UrlRoute extension to fallback to the file when needed
* [x] Update our disabled routes component to fallback to the file when needed
