### PR TITLE
namespace seems to break the migrations

### DIFF
--- a/backend/modules/sales/config/console.php
+++ b/backend/modules/sales/config/console.php
@@ -3,7 +3,7 @@ return [
   'controllerMap' => [
     'migrate-sales' => [
         'class' => 'yii\console\controllers\MigrateController',
-        'migrationNamespaces' => ['app\modules\sales\migrations'],
+        //'migrationNamespaces' => ['app\modules\sales\migrations'],
         'migrationTable' => 'migration_sales',
         'migrationPath' => '@app/modules/sales/migrations',
         //'migrationPath' => null,

--- a/backend/modules/sales/migrations/m210203_210227_add_stripe_customer_id_column_to_player_table.php
+++ b/backend/modules/sales/migrations/m210203_210227_add_stripe_customer_id_column_to_player_table.php
@@ -1,5 +1,4 @@
 <?php
-namespace app\modules\sales\migrations;
 
 use yii\db\Migration;
 

--- a/backend/modules/sales/migrations/m210203_214148_create_stripe_webhook_table.php
+++ b/backend/modules/sales/migrations/m210203_214148_create_stripe_webhook_table.php
@@ -1,5 +1,4 @@
 <?php
-namespace app\modules\sales\migrations;
 
 use yii\db\Migration;
 

--- a/backend/modules/sales/migrations/m210203_233709_create_player_subscription_table.php
+++ b/backend/modules/sales/migrations/m210203_233709_create_player_subscription_table.php
@@ -1,5 +1,4 @@
 <?php
-namespace app\modules\sales\migrations;
 
 use yii\db\Migration;
 

--- a/backend/modules/sales/migrations/m210206_125913_create_product_table.php
+++ b/backend/modules/sales/migrations/m210206_125913_create_product_table.php
@@ -1,5 +1,4 @@
 <?php
-namespace app\modules\sales\migrations;
 
 use yii\db\Migration;
 

--- a/backend/modules/sales/migrations/m210208_231414_create_headhunter_transfer_event.php
+++ b/backend/modules/sales/migrations/m210208_231414_create_headhunter_transfer_event.php
@@ -1,5 +1,4 @@
 <?php
-namespace app\modules\sales\migrations;
 
 use yii\db\Migration;
 

--- a/backend/modules/sales/migrations/m210208_232740_create_junction_table_for_product_and_network_tables.php
+++ b/backend/modules/sales/migrations/m210208_232740_create_junction_table_for_product_and_network_tables.php
@@ -1,5 +1,4 @@
 <?php
-namespace app\modules\sales\migrations;
 
 use yii\db\Migration;
 

--- a/backend/modules/sales/migrations/m210208_232789_create_do_subscription_expiration_procedure.php
+++ b/backend/modules/sales/migrations/m210208_232789_create_do_subscription_expiration_procedure.php
@@ -1,5 +1,4 @@
 <?php
-namespace app\modules\sales\migrations;
 
 use yii\db\Migration;
 

--- a/backend/modules/sales/migrations/m210210_131842_add_subscription_badges.php
+++ b/backend/modules/sales/migrations/m210210_131842_add_subscription_badges.php
@@ -1,5 +1,4 @@
 <?php
-namespace app\modules\sales\migrations;
 
 use yii\db\Migration;
 


### PR DESCRIPTION
This PR fixes #674 by hooking the sales migrations to the normal installation processes and main documentation.