### PR TITLE
Improve error pages

### DIFF
--- a/frontend/components/BaseController.php
+++ b/frontend/components/BaseController.php
@@ -132,7 +132,7 @@ class BaseController extends \yii\web\Controller
     {
       if ($this->enableCsrfValidation && Yii::$app->getErrorHandler()->exception === null && !$this->request->validateCsrfToken())
       {
-        if(!\Yii::$app->user->isGuest)
+        if(defined('YII_DEBUG') && !\Yii::$app->user->isGuest)
         {
           \Yii::error("CSRF-FAIL");
           \Yii::error(var_export($this->enableCsrfValidation, true));
@@ -143,8 +143,7 @@ class BaseController extends \yii\web\Controller
           \Yii::error(var_export($_SESSION, true));
         }
         Yii::$app->session->setFlash('error', Yii::t('yii', 'Unable to verify your submission CSRF token, please try again.'));
-        $this->goBack(Yii::$app->request->referrer ?: [Yii::$app->sys->default_homepage]);
-        return false;
+        return $this->redirect(Yii::$app->request->referrer ?: [Yii::$app->sys->default_homepage]);
       }
       return parent::beforeAction($action);
     }

--- a/frontend/controllers/SiteController.php
+++ b/frontend/controllers/SiteController.php
@@ -272,7 +272,8 @@ class SiteController extends \app\components\BaseController
         }
         catch(InvalidArgumentException $e)
         {
-            throw new BadRequestHttpException($e->getMessage());
+            Yii::$app->session->setFlash('warning', 'Password reset token not found! If you have changed your password already try to sign-in.');
+            return $this->redirect(['/site/login']);
         }
 
         if($model->load(Yii::$app->request->post()) && $model->validate() && $model->resetPassword())
@@ -309,7 +310,8 @@ class SiteController extends \app\components\BaseController
         }
         catch(InvalidArgumentException $e)
         {
-            throw new BadRequestHttpException($e->getMessage());
+            Yii::$app->session->setFlash('warning', 'Verification token not found! Try to login if you have verified your email already.');
+            return $this->redirect(['/site/login']);
         }
         $post=Yii::$app->request->post('VerifyEmailForm');
         $value=ArrayHelper::getValue($post, 'token');
@@ -336,8 +338,8 @@ class SiteController extends \app\components\BaseController
           $transaction->rollBack();
         }
 
-        Yii::$app->session->setFlash('error', 'Sorry, we are unable to verify your account with provided token.');
-        return $this->goHome();
+        Yii::$app->session->setFlash('error', 'Sorry, we are unable to verify an account with the provided token.');
+        return $this->redirect(['/']);
     }
 
     /**


### PR DESCRIPTION
This PR replaces some error pages with redirects and UI notifications to make the experience less scary for the users
* [x] Reset Password change error page on wrong token with a redirect to the login and fire a notification.
* [x] Verify Email change error page on wrong token with a redirect to the login and fire a notification - fixes #699
* [x] On CSRF validation failure redirect back to referrer or default homepage - fixes #700 