### PR TITLE
Introduce the ability to hide inactive targets from the frontend

### DIFF
--- a/docs/Sysconfig-Keys.md
+++ b/docs/Sysconfig-Keys.md
@@ -12,6 +12,8 @@
 * `leaderboard_visible_before_event_start`: Show leaderboard before event start
 * `all_players_vip`: Allow all players to have VIP features enabled
 * `target_guest_view_deny`: Deny guests to target/view and target/versus
+* `target_hide_inactive`: Hide inactive targets from the frontend listings. This includes upcoming powerups
+
 
 Not activated by default on current code-base but are going to
 * _`require_activation`_ Whether it is required for users to activate their accounts

--- a/frontend/modules/target/models/TargetQuery.php
+++ b/frontend/modules/target/models/TargetQuery.php
@@ -1,51 +1,78 @@
 <?php
+
 namespace app\modules\target\models;
 
 use Yii;
 
 class TargetQuery extends \yii\db\ActiveQuery
 {
-      public function forNet(int $network_id)
-      {
-        return $this->join('LEFT JOIN','network_target','network_target.target_id=t.id')->andWhere(['network_target.network_id'=>$network_id]);
-      }
-      public function timed()
-      {
-        return $this->andWhere(['timer' => 1]);
-      }
+  public function init()
+  {
+    if (Yii::$app->sys->target_hide_inactive === true) {
+      $this->andOnCondition('active = :target_hide_inactive', [':target_hide_inactive' => 1]);
+    }
+    parent::init();
+  }
 
-      public function active()
-      {
-        return $this->andWhere(['active' => 1]);
-      }
+  public function forNet(int $network_id)
+  {
+    return $this->join('LEFT JOIN', 'network_target', 'network_target.target_id=t.id')->andWhere(['network_target.network_id' => $network_id]);
+  }
 
-      public function not_in_network()
-      {
-        return $this->andWhere(['on_network'=>0]);
-      }
+  public function timed()
+  {
+    return $this->andWhere(['timer' => 1]);
+  }
 
-      public function forView($player_id)
-      {
-        $this->alias('t');
-        $this->select(['t.*']);
-        $this->addSelect(['INET_NTOA(t.ip) as ipoctet']);
-        $this->addSelect(['on_ondemand','ondemand_state','timer_avg']);
-        $this->addSelect('total_treasures, total_findings, player_treasures, player_findings, ((player_treasures+player_findings)/(total_treasures+total_findings))*100 as progress, player_rating, total_headshots, total_writeups, approved_writeups,player_points');
-        $this->join('LEFT JOIN', 'target_state', 'target_state.id=t.id');
-        $this->join('LEFT JOIN','target_player_state','target_player_state.id=t.id AND target_player_state.player_id='.intval($player_id));
-        return $this;
-      }
+  public function active()
+  {
+    return $this->andWhere(['active' => 1]);
+  }
 
-      public function player_progress($player_id=0)
-      {
-        $this->alias('t');
-        $this->select(['t.id', 't.name', 't.status', 't.active', 't.ip', 't.difficulty', 'rootable','t.scheduled_at','t.ts','t.player_spin']);
-        $this->addSelect(['INET_NTOA(t.ip) as ipoctet']);
-        $this->addSelect(['on_ondemand','ondemand_state']);
-        $this->addSelect('total_treasures, total_findings, player_treasures, player_findings, ((player_treasures+player_findings)/(total_treasures+total_findings))*100 as progress, player_rating, total_headshots, total_writeups, approved_writeups,player_points');
-        $this->join('LEFT JOIN', 'target_state', 'target_state.id=t.id');
-        $this->join('LEFT JOIN','target_player_state','target_player_state.id=t.id AND target_player_state.player_id='.intval($player_id));
-        return $this;
-      }
+  public function not_in_network()
+  {
+    return $this->andWhere(['on_network' => 0]);
+  }
 
+  public function forView($player_id)
+  {
+    $this->alias('t');
+    $this->select(['t.*']);
+    $this->addSelect(['INET_NTOA(t.ip) as ipoctet']);
+    $this->addSelect(['on_ondemand', 'ondemand_state', 'timer_avg']);
+    $this->addSelect('total_treasures, total_findings, player_treasures, player_findings, ((player_treasures+player_findings)/(total_treasures+total_findings))*100 as progress, player_rating, total_headshots, total_writeups, approved_writeups,player_points');
+    $this->join('LEFT JOIN', 'target_state', 'target_state.id=t.id');
+    $this->join('LEFT JOIN', 'target_player_state', 'target_player_state.id=t.id AND target_player_state.player_id=' . intval($player_id));
+    return $this;
+  }
+
+  public function player_progress($player_id = 0)
+  {
+    $this->alias('t');
+    $this->select(['t.id', 't.name', 't.status', 't.active', 't.ip', 't.difficulty', 'rootable', 't.scheduled_at', 't.ts', 't.player_spin']);
+    $this->addSelect(['INET_NTOA(t.ip) as ipoctet']);
+    $this->addSelect(['on_ondemand', 'ondemand_state']);
+    $this->addSelect('total_treasures, total_findings, player_treasures, player_findings, ((player_treasures+player_findings)/(total_treasures+total_findings))*100 as progress, player_rating, total_headshots, total_writeups, approved_writeups,player_points');
+    $this->join('LEFT JOIN', 'target_state', 'target_state.id=t.id');
+    $this->join('LEFT JOIN', 'target_player_state', 'target_player_state.id=t.id AND target_player_state.player_id=' . intval($player_id));
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   * @return Target[]|array
+   */
+  public function all($db = null)
+  {
+    return parent::all($db);
+  }
+
+  /**
+   * {@inheritdoc}
+   * @return Target|array|null
+   */
+  public function one($db = null)
+  {
+    return parent::one($db);
+  }
 }


### PR DESCRIPTION
The following PR:
* introduces the sysconfig key `target_hide_inactive`
* updates the TargetQuery to include `active=1` when the key is active

fixes #753