### PR TITLE
Json encode all sysconfig keys

### DIFF
--- a/backend/migrations/m221215_212831_update_tai_sysconfig_serialize_json_all.php
+++ b/backend/migrations/m221215_212831_update_tai_sysconfig_serialize_json_all.php
@@ -1,0 +1,34 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m221215_212831_update_tai_sysconfig_serialize_json_all
+ */
+class m221215_212831_update_tai_sysconfig_serialize_json_all extends Migration
+{
+  public $DROP_SQL = "DROP TRIGGER IF EXISTS {{%tai_sysconfig}}";
+  public $CREATE_SQL = "CREATE TRIGGER {{%tai_sysconfig}} AFTER INSERT ON {{%sysconfig}} FOR EACH ROW
+    thisBegin:BEGIN
+      IF (@TRIGGER_CHECKS = FALSE) THEN
+          LEAVE thisBegin;
+      END IF;
+
+      IF (select memc_server_count()<1) THEN
+        select memc_servers_set('127.0.0.1') INTO @memc_server_set_status;
+      END IF;
+      DO memc_set('sysconfig_json',(SELECT CONCAT('[',GROUP_CONCAT(JSON_OBJECT('id', id,'val',val) ORDER BY id),']') FROM sysconfig WHERE id NOT LIKE 'CA%' and id NOT IN ('disabled_routes','frontpage_scenario','routes','writeup_rules','vpn-ta.key') ORDER BY id));
+      DO memc_set(CONCAT('sysconfig:',NEW.id),NEW.val);
+    END";
+
+  public function up()
+  {
+    $this->db->createCommand($this->DROP_SQL)->execute();
+    $this->db->createCommand($this->CREATE_SQL)->execute();
+  }
+
+  public function down()
+  {
+    $this->db->createCommand($this->DROP_SQL)->execute();
+  }
+}

--- a/backend/migrations/m221215_212839_update_tad_sysconfig_serialize_json_all.php
+++ b/backend/migrations/m221215_212839_update_tad_sysconfig_serialize_json_all.php
@@ -1,0 +1,34 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m221215_212839_update_tad_sysconfig_serialize_json_all
+ */
+class m221215_212839_update_tad_sysconfig_serialize_json_all extends Migration
+{
+  public $DROP_SQL = "DROP TRIGGER IF EXISTS {{%tad_sysconfig}}";
+  public $CREATE_SQL = "CREATE TRIGGER {{%tad_sysconfig}} AFTER DELETE ON {{%sysconfig}} FOR EACH ROW
+    thisBegin:BEGIN
+      IF (@TRIGGER_CHECKS = FALSE) THEN
+          LEAVE thisBegin;
+      END IF;
+
+    IF (select memc_server_count()<1) THEN
+      select memc_servers_set('127.0.0.1') INTO @memc_server_set_status;
+    END IF;
+    DO memc_set('sysconfig_json',(SELECT CONCAT('[',GROUP_CONCAT(JSON_OBJECT('id', id,'val',val) ORDER BY id),']') FROM sysconfig WHERE id NOT LIKE 'CA%' and id NOT IN ('disabled_routes','frontpage_scenario','routes','writeup_rules','vpn-ta.key') ORDER BY id));
+    DO memc_delete(CONCAT('sysconfig:',OLD.id));
+  END";
+
+  public function up()
+  {
+    $this->db->createCommand($this->DROP_SQL)->execute();
+    $this->db->createCommand($this->CREATE_SQL)->execute();
+  }
+
+  public function down()
+  {
+    $this->db->createCommand($this->DROP_SQL)->execute();
+  }
+}

--- a/backend/migrations/m221215_212842_update_tau_sysconfig_serialize_json_all.php
+++ b/backend/migrations/m221215_212842_update_tau_sysconfig_serialize_json_all.php
@@ -1,0 +1,36 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m221215_212842_update_tau_sysconfig_serialize_json_all
+ */
+class m221215_212842_update_tau_sysconfig_serialize_json_all extends Migration
+{
+  public $DROP_SQL = "DROP TRIGGER IF EXISTS {{%tau_sysconfig}}";
+  public $CREATE_SQL = "CREATE TRIGGER {{%tau_sysconfig}} AFTER UPDATE ON {{%sysconfig}} FOR EACH ROW
+  thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    IF (select memc_server_count()<1) THEN
+      select memc_servers_set('127.0.0.1') INTO @memc_server_set_status;
+    END IF;
+    IF NEW.id != OLD.id THEN
+      SELECT memc_delete(CONCAT('sysconfig:',OLD.id)) INTO @devnull;
+    END IF;
+    DO memc_set('sysconfig_json',(SELECT CONCAT('[',GROUP_CONCAT(JSON_OBJECT('id', id,'val',val) ORDER BY id),']') FROM sysconfig WHERE id NOT LIKE 'CA%' and id NOT IN ('disabled_routes','frontpage_scenario','routes','writeup_rules','vpn-ta.key') ORDER BY id));
+    DO memc_set(CONCAT('sysconfig:',NEW.id),NEW.val);
+  END";
+
+  public function up()
+  {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+  }
+
+  public function down()
+  {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+  }
+}

--- a/backend/migrations/m221215_214626_update_populate_memcache_procedure_include_serialized_sysconfig.php
+++ b/backend/migrations/m221215_214626_update_populate_memcache_procedure_include_serialized_sysconfig.php
@@ -1,0 +1,36 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m221215_214626_update_populate_memcache_procedure_include_serialized_sysconfig
+ */
+class m221215_214626_update_populate_memcache_procedure_include_serialized_sysconfig extends Migration
+{
+  public $DROP_SQL = "DROP PROCEDURE IF EXISTS {{%populate_memcache}}";
+  public $CREATE_SQL = "CREATE PROCEDURE {{%populate_memcache}} ()
+  BEGIN
+    select memc_servers_set('127.0.0.1') INTO @memc_server_set_status;
+    INSERT INTO devnull SELECT memc_set(CONCAT('player:',id),id) FROM player;
+    INSERT INTO devnull SELECT memc_set(CONCAT('player_type:',id),`type`) FROM player;
+    INSERT INTO devnull SELECT memc_set(CONCAT('team_player:',player_id),team_id) FROM team_player;
+    INSERT INTO devnull SELECT memc_set(CONCAT('team_finding:',t2.team_id, ':', t1.finding_id),t1.player_id) FROM player_finding AS t1 LEFT JOIN team_player AS t2 ON t2.player_id=t1.player_id;
+    INSERT INTO devnull SELECT memc_set(CONCAT('player_finding:',player_id, ':', finding_id),player_id) FROM player_finding;
+    INSERT INTO devnull SELECT memc_set(CONCAT('target:',ip),id) FROM target;
+    INSERT INTO devnull SELECT memc_set(CONCAT('target:',id),ip) FROM target;
+    INSERT INTO devnull SELECT memc_set(CONCAT('sysconfig:',id),val) FROM sysconfig;
+    INSERT INTO devnull SELECT memc_set(CONCAT('finding:',protocol,':',ifnull(port,0), ':', target_id ),id) FROM finding;
+    DO memc_set('sysconfig_json',(SELECT CONCAT('[',GROUP_CONCAT(JSON_OBJECT('id', id,'val',val) ORDER BY id),']') FROM sysconfig WHERE id NOT LIKE 'CA%' and id NOT IN ('disabled_routes','frontpage_scenario','routes','writeup_rules','vpn-ta.key') ORDER BY id));
+  END";
+  // Use up()/down() to run migration code without a transaction.
+  public function up()
+  {
+    $this->db->createCommand($this->DROP_SQL)->execute();
+    $this->db->createCommand($this->CREATE_SQL)->execute();
+  }
+
+  public function down()
+  {
+    $this->db->createCommand($this->DROP_SQL)->execute();
+  }
+}

--- a/frontend/components/Sysconfig.php
+++ b/frontend/components/Sysconfig.php
@@ -67,7 +67,15 @@ class Sysconfig extends Component
     {
       $this->keyCache=require Yii::getAlias('@app/config/sysconfig.php');
     }
-
+    $raw=Yii::$app->cache->memcache->get('sysconfig_json');
+    $decoded=json_decode($raw);
+    if(json_last_error()===JSON_ERROR_NONE)
+    {
+      foreach($decoded as $obj)
+      {
+        $this->keyCache['sysconfig:'.$obj->id]=$obj->val;
+      }
+    }
     //if(\Yii::$app->cache->memcache instanceof \MemCache)
     //  $this->keyCache=Yii::$app->cache->memcache->get($this->prefetchKeys);
   }


### PR DESCRIPTION
This PR introduces a new sysconfig key `sysconfig_json` (notice it is not prefixed) which includes all the sysconfig keys json encoded. There are a few keys excluded due to size considerations. These keys are **`CA*`, `disabled_routes`, `frontpage_scenario`, `routes`, `writeup_rules`, `vpn-ta.key`**

On some local preliminary tests, the pho execution time of each page did not exceed 39-40ms for processing and sending data (the css and js files still add up but not when they are cached)

fixes #717