### PR TITLE
Add unannounced network flag

### DIFF
--- a/backend/migrations/m221219_213856_add_announce_column_to_network_table.php
+++ b/backend/migrations/m221219_213856_add_announce_column_to_network_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles adding columns to table `{{%network}}`.
+ */
+class m221219_213856_add_announce_column_to_network_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{%network}}', 'announce', $this->boolean()->defaultValue(1)->after('active'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{%network}}', 'announce');
+    }
+}

--- a/backend/modules/gameplay/models/Network.php
+++ b/backend/modules/gameplay/models/Network.php
@@ -16,6 +16,7 @@ use yii\behaviors\AttributeTypecastBehavior;
  * @property string $description
  * @property boolean $public
  * @property boolean $active
+ * @property integer $announce
  * @property integer $weight
  * @property string $ts
  *
@@ -42,7 +43,7 @@ class Network extends \yii\db\ActiveRecord
         return [
             [['name','codename'], 'required'],
             [['description','codename','icon'], 'string'],
-            [['public','active'], 'boolean'],
+            [['public','active','announce'], 'boolean'],
             [['ts'], 'safe'],
             [['name'], 'string', 'max' => 32],
             [['name'], 'unique'],
@@ -58,6 +59,7 @@ class Network extends \yii\db\ActiveRecord
                 'class' => AttributeTypecastBehavior::class,
                 'attributeTypes' => [
                     'active' => AttributeTypecastBehavior::TYPE_BOOLEAN,
+                    'announce' => AttributeTypecastBehavior::TYPE_BOOLEAN,
                     'public' => AttributeTypecastBehavior::TYPE_BOOLEAN,
                 ],
                 'typecastAfterValidate' => false,

--- a/backend/modules/gameplay/models/NetworkSearch.php
+++ b/backend/modules/gameplay/models/NetworkSearch.php
@@ -18,7 +18,7 @@ class NetworkSearch extends Network
     {
         return [
             [['id','weight'], 'integer'],
-            [['public', 'active'], 'boolean'],
+            [['public', 'active','announce'], 'boolean'],
             [['name', 'description', 'codename', 'icon', 'ts'], 'safe'],
         ];
     }
@@ -62,6 +62,7 @@ class NetworkSearch extends Network
             'id' => $this->id,
             'weight' => $this->weight,
             'active' => $this->active,
+            'announce' => $this->announce,
             'public' => $this->public,
             'ts' => $this->ts,
         ]);

--- a/backend/modules/gameplay/models/Target.php
+++ b/backend/modules/gameplay/models/Target.php
@@ -276,11 +276,12 @@ class Target extends TargetAR
 
   public function addNews()
   {
+    if($this->network!==null && ($this->network->announce===false || $this->network->active===false)) return ;
     $news=new \app\modules\content\models\News;
     $news->title=sprintf(\Yii::t('app',"New target %s added"),$this->name);
     $news->category=H::img("/images/news/category/new-target.svg",['width'=>'25px']);
     $body=sprintf(\Yii::t('app',"Just a heads up, new target [%s]"),H::a($this->name,'/target/'.$this->id));
-    $bodyPlain=sprintf(\Yii::t('app',"Hey everyone, just a heads up, new target [**%s**] => https://%s/target/%d"),$this->name,Yii::$app->sys->offense_domain,$this->id);
+    $bodyPlain=sprintf(\Yii::t('app',"Hey @everyone, just a heads up, new target [**%s**] => https://%s/target/%d"),$this->name,Yii::$app->sys->offense_domain,$this->id);
     if($this->network!==null)
     {
       $bodyPlain=sprintf(\Yii::t('app',"%s got added to the [**%s**]"),$bodyPlain,$this->network->name);

--- a/backend/modules/infrastructure/models/NetworkTargetSchedule.php
+++ b/backend/modules/infrastructure/models/NetworkTargetSchedule.php
@@ -120,6 +120,8 @@ class NetworkTargetSchedule extends \yii\db\ActiveRecord
 
   public function addNews()
   {
+    if($this->network!==null && ($this->network->announce===false || $this->network->active===false)) return;
+
     $news=new \app\modules\content\models\News;
     $news->title=sprintf(\Yii::t('app',"Target %s migrated"),$this->target->name);
     $news->category=H::img("/images/news/category/target-migration.svg",['width'=>'25px']);
@@ -130,7 +132,12 @@ class NetworkTargetSchedule extends \yii\db\ActiveRecord
     }
     else
     {
-      $bodyPlain=sprintf(\Yii::t('app',"Hi @everyone, just a heads up, the target [**%s**] => https://%s/target/%d got migrated to the network [**%s**] and its ready for you to headshot.\n\nHave fun and Happy Hacking :heart:"),$this->target->name,Yii::$app->sys->offense_domain,$this->target_id,$this->network->name);
+      if($this->target->status=='online')
+        $bodyPlain=sprintf(\Yii::t('app',"Hi @everyone, just a heads up, the target [**%s**] => https://%s/target/%d got migrated to the [**%s**] and its ready for you to headshot.\n\nHave fun and Happy Hacking :heart:"),$this->target->name,Yii::$app->sys->offense_domain,$this->target_id,$this->network->name);
+      else if($this->target->scheduled_at && $this->target->status=='powerup')
+        $bodyPlain=sprintf(\Yii::t('app',"Hi @everyone, just a heads up, the target [**%s**] => https://%s/target/%d got migrated to the [**%s**] and will become available at %s.\n\nHave fun and Happy Hacking :heart:"),$this->target->name,Yii::$app->sys->offense_domain,$this->target_id,$this->network->name,$this->target->scheduled_at);
+
+
       $news->body=sprintf(\Yii::t('app',"Just a heads up, the target [%s], got migrated to a new network [%s]."),H::a($this->target->name,'/target/'.$this->target_id),H::a($this->network->name,'/network/'.$this->network_id));
     }
     if(Yii::$app->sys->discord_news_webhook!==false)

--- a/backend/modules/infrastructure/views/network/_form.php
+++ b/backend/modules/infrastructure/views/network/_form.php
@@ -18,6 +18,7 @@ use yii\widgets\ActiveForm;
     <?= $form->field($model, 'weight')->textInput(['maxlength' => true]) ?>
     <?= $form->field($model, 'public')->checkbox() ?>
     <?= $form->field($model, 'active')->checkbox() ?>
+    <?= $form->field($model, 'announce')->checkbox() ?>
     <?= $form->field($model, 'description')->textarea(['rows' => 6]) ?>
 
     <?= $form->field($model, 'ts')->textInput() ?>

--- a/backend/modules/infrastructure/views/network/index.php
+++ b/backend/modules/infrastructure/views/network/index.php
@@ -39,6 +39,7 @@ yii\bootstrap\Modal::end();
             'description:ntext',
             'public:boolean',
             'active:boolean',
+            'announce:boolean',
             'icon',
             'weight:integer',
             'ts',

--- a/backend/modules/infrastructure/views/network/view.php
+++ b/backend/modules/infrastructure/views/network/view.php
@@ -36,6 +36,7 @@ $this->params['breadcrumbs'][]=$this->title;
           'description:ntext',
           'public:boolean',
           'active:boolean',
+          'announce:boolean',
           'weight:integer',
           'ts',
         ],


### PR DESCRIPTION
This PR does:
* adds an `announce` column to the network table (for whether or not target additions to it should be announced to news and discord)
* updates the target and network target schedule to respect that when sending news items
* changes the target news message to include `@everyone`