### PR TITLE
Escape flash messages that receive untrusted input

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,7 +1,9 @@
 # Credits
 We would like to thank the following people for their contributions, support and persistence :)
-* @HitmanAlharbi for numerous contributions and support
+* @HitmanAlharbi for numerous contributions, bug reports and support
 * @harperaa for suggestions on, and testing of our documentation
+* @Pegasus0xx for reporting XSS in the backend operations
+* @bibaf for support and bug reports to the frontend and backend operations
 
 Original project could not have been made possible without the help and contributions of the following
 * @gadamo, @pkotsiop, @akorovesi

--- a/backend/modules/activity/controllers/NotificationController.php
+++ b/backend/modules/activity/controllers/NotificationController.php
@@ -9,6 +9,7 @@ use app\modules\frontend\models\Player;
 use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
 
 /**
  * NotificationController implements the CRUD actions for Notification model.
@@ -73,7 +74,7 @@ class NotificationController extends \app\components\BaseController
             $notif->load(Yii::$app->request->post());
             $notif->player_id = $player->id;
             if (!$notif->save()) {
-              \Yii::$app->getSession()->addFlash('error', $notif->getErrorSummary(true));
+              \Yii::$app->getSession()->addFlash('error', Html::errorSummary($notif));
               $err = true;
             }
           }
@@ -84,12 +85,12 @@ class NotificationController extends \app\components\BaseController
           }
         } catch (\Exception $e) {
           $transaction->rollBack();
-          \Yii::$app->getSession()->addFlash('error', $e->getMessage());
+          \Yii::$app->getSession()->addFlash('error', Html::encode($e->getMessage()));
         }
       } else if ($model->save()) {
         return $this->redirect(['view', 'id' => $model->id]);
       } else {
-        \Yii::$app->getSession()->addFlash('error', $model->getErrorSummary(true));
+        \Yii::$app->getSession()->addFlash('error', Html::errorSummary($model));
       }
     }
     return $this->render('create', [

--- a/backend/modules/activity/controllers/SessionController.php
+++ b/backend/modules/activity/controllers/SessionController.php
@@ -8,6 +8,7 @@ use app\modules\activity\models\SessionsSearch;
 use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
 
 /**
  * SessionController implements the CRUD actions for Sessions model.

--- a/backend/modules/frontend/actions/player/ImportAction.php
+++ b/backend/modules/frontend/actions/player/ImportAction.php
@@ -11,6 +11,7 @@ use app\modules\frontend\models\PlayerSearch;
 use app\modules\settings\models\Sysconfig;
 use app\modules\frontend\models\ImportPlayerForm;
 use yii\web\UploadedFile;
+use yii\helpers\Html;
 
 class ImportAction extends \yii\base\Action
 {
@@ -40,7 +41,7 @@ class ImportAction extends \yii\base\Action
               catch(\Exception $e)
               {
                 $trans->rollBack();
-                Yii::$app->session->setFlash('error', 'Failed to import file, '.$e->getMessage());
+                Yii::$app->session->setFlash('error', 'Failed to import file, '.Html::encode($e->getMessage()));
               }
           }
       }

--- a/backend/modules/frontend/actions/player/MailAction.php
+++ b/backend/modules/frontend/actions/player/MailAction.php
@@ -9,6 +9,7 @@ use app\modules\frontend\models\TeamPlayer;
 use app\modules\frontend\models\PlayerSsl;
 use app\modules\frontend\models\PlayerSearch;
 use app\modules\settings\models\Sysconfig;
+use yii\helpers\Html;
 
 class MailAction extends \yii\base\Action
 {
@@ -23,7 +24,7 @@ class MailAction extends \yii\base\Action
     $player=$this->controller->findModel($id);
     if($player->status==10)
     {
-      \Yii::$app->getSession()->setFlash('warning', 'Player already active skiping mail.');
+      \Yii::$app->getSession()->setFlash('warning', 'Player already active skipping mail.');
       return $this->controller->goBack(Yii::$app->request->referrer);
     }
     elseif($player->status==9)
@@ -45,7 +46,7 @@ class MailAction extends \yii\base\Action
         }
         catch(\Exception $e)
         {
-          \Yii::$app->getSession()->setFlash('error', 'Failed to mail player. '.$e->getMessage());
+          \Yii::$app->getSession()->setFlash('error', 'Failed to mail player. '.Html::encode($e->getMessage()));
         }
     }
     elseif($player->status==0)
@@ -67,7 +68,7 @@ class MailAction extends \yii\base\Action
         }
         catch(\Exception $e)
         {
-          \Yii::$app->getSession()->setFlash('error', 'Failed to mail rejection to player. '.$e->getMessage());
+          \Yii::$app->getSession()->setFlash('error', 'Failed to mail rejection to player. '.Html::encode($e->getMessage()));
         }
 
     }

--- a/backend/modules/frontend/controllers/PlayerController.php
+++ b/backend/modules/frontend/controllers/PlayerController.php
@@ -13,6 +13,7 @@ use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
 use yii\web\UploadedFile;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
 
 /**
  * PlayerController implements the CRUD actions for Player model.
@@ -157,7 +158,7 @@ class PlayerController extends \app\components\BaseController
       catch(\Exception $e)
       {
         $trans->rollBack();
-        \Yii::$app->getSession()->setFlash('error', 'Failed to create player. '.$e->getMessage());
+        \Yii::$app->getSession()->setFlash('error', 'Failed to create player. '.Html::encode($e->getMessage()));
       }
       return $this->render('create', [
           'model' => $model,
@@ -197,7 +198,7 @@ class PlayerController extends \app\components\BaseController
     {
 
         if(($model=Player::findOne($id)) !== null && $model->delete() !== false)
-          Yii::$app->session->setFlash('success', sprintf('Player [%s] deleted.', $model->username));
+          Yii::$app->session->setFlash('success', sprintf('Player [%s] deleted.', Html::encode($model->username)));
         else
           Yii::$app->session->setFlash('error', 'Player deletion failed.');
         return $this->redirect(['index']);
@@ -248,7 +249,7 @@ class PlayerController extends \app\components\BaseController
           $model->team->delete();
         }
         $trans->commit();
-        Yii::$app->session->setFlash('success', 'User ['.$model->username.'] academic set to '.$model->academic);
+        Yii::$app->session->setFlash('success', 'User ['.Html::encode($model->username).'] academic set to '.Html::encode($model->academic));
       }
       catch(\Exception $e)
       {
@@ -273,7 +274,7 @@ class PlayerController extends \app\components\BaseController
         $model=$this->findModel($id);
         $model->updateAttributes(['active' => !$model->active]);
         $trans->commit();
-        Yii::$app->session->setFlash('success', 'User ['.$model->username.'] active set to '.$model->active);
+        Yii::$app->session->setFlash('success', 'User ['.Html::encode($model->username).'] active set to '.Html::encode($model->active));
       }
       catch(\Exception $e)
       {

--- a/backend/modules/frontend/controllers/TeamController.php
+++ b/backend/modules/frontend/controllers/TeamController.php
@@ -10,6 +10,7 @@ use app\modules\frontend\models\TeamPlayerSearch;
 use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
 
 /**
  * TeamController implements the CRUD actions for Team model.
@@ -98,7 +99,7 @@ class TeamController extends \app\components\BaseController
         catch (\Exception $e)
         {
           $trans->rollBack();
-          \Yii::$app->getSession()->setFlash('error', 'Failed to create team. '.$e->getMessage());
+          \Yii::$app->getSession()->setFlash('error', 'Failed to create team. '.Html::encode($e->getMessage()));
         }
         return $this->render('create', [
             'model' => $model,

--- a/backend/modules/frontend/models/PlayerAR.php
+++ b/backend/modules/frontend/models/PlayerAR.php
@@ -99,17 +99,18 @@ class PlayerAR extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['username', 'type', 'status'], 'required'],
+            [['username', 'type', 'status','email'], 'required'],
             [['type'], 'string'],
             [['active', 'status'], 'integer'],
             [['academic'], 'integer'],
             [['academic'], 'default','value'=>0],
+            [['password_hash'], 'default', 'value'=>""],
             [['email'], 'filter', 'filter'=>'strtolower'],
-            [['activkey'], 'string', 'max' => 32],
+            [['activkey'], 'string', 'max' => 43],
             [['auth_key'], 'string', 'max' => 32],
             [['type'], 'default', 'value' => 'offense'],
             [['status'], 'default', 'value' => self::STATUS_ACTIVE],
-            [['activkey'], 'default', 'value' => Yii::$app->security->generateRandomString().'_'.time(), 'on' => 'create'],
+            [['activkey'], 'default', 'value' => Yii::$app->security->generateRandomString().'-'.time(), 'on' => 'create'],
             [['verification_token'], 'default', 'value' => str_replace('_','-',Yii::$app->security->generateRandomString().'-'.time()), 'on' => 'create'],
             [['username', 'fullname', 'email', 'new_password', 'activkey'], 'string', 'max' => 255],
             [['username'], 'unique'],
@@ -442,6 +443,5 @@ class PlayerAR extends \yii\db\ActiveRecord
     {
         return $this->auth_key;
     }
-
 
 }

--- a/backend/modules/gameplay/controllers/ChallengeController.php
+++ b/backend/modules/gameplay/controllers/ChallengeController.php
@@ -12,6 +12,7 @@ use yii\filters\VerbFilter;
 use yii\web\UploadedFile;
 use yii\data\ActiveDataProvider;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
 
 /**
  * ChallengeController implements the CRUD actions for Challenge model.
@@ -100,11 +101,11 @@ class ChallengeController extends \app\components\BaseController
             {
               if($model->file)
                 $model->file->saveAs('uploads/'.$model->id);
-              Yii::$app->session->setFlash('success', 'Challenge ['.$model->name.'] created.');
+              Yii::$app->session->setFlash('success', 'Challenge ['.Html::encode($model->name).'] created.');
             }
             catch(\Exception $e)
             {
-              Yii::$app->session->setFlash('error', 'Failed to create challenge ['.$model->name.']');
+              Yii::$app->session->setFlash('error', 'Failed to create challenge ['.Html::encode($model->name).']');
             }
             return $this->redirect(['view', 'id' => $model->id]);
         }

--- a/backend/modules/infrastructure/controllers/TargetController.php
+++ b/backend/modules/infrastructure/controllers/TargetController.php
@@ -15,6 +15,7 @@ use Docker\API\Model\ExecIdStartPostBody;
 use Http\Client\Socket\Exception\ConnectionException;
 use yii\data\ArrayDataProvider;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
 
 /**
  * TargetController implements the CRUD actions for Target model.
@@ -151,7 +152,7 @@ class TargetController extends \app\components\BaseController
         }
         catch(\Exception $e)
         {
-          Yii::$app->session->setFlash('error', "Failed to fetch logs. <b>".$e->getMessage().'</b>');
+          Yii::$app->session->setFlash('error', "Failed to fetch logs. <b>".Html::encode($e->getMessage()).'</b>');
           return $this->redirect(['view','id'=>$target->id]);
         }
         return $this->render('logs', [
@@ -249,7 +250,7 @@ class TargetController extends \app\components\BaseController
     {
         $model=$this->findModel($id);
         $modelOrig=$this->findModel($id);
-        $msg="Server updated succesfully";
+        $msg="Server updated successfully";
         if($model->load(Yii::$app->request->post()) && $model->validate())
         {
 
@@ -257,14 +258,14 @@ class TargetController extends \app\components\BaseController
           if($modelOrig->server != $model->server || array_key_exists('destroy', Yii::$app->request->post()))
           {
             $modelOrig->destroy();
-            $msg="Server destroyed and updated succesfully";
+            $msg="Server destroyed and updated successfully";
           }
           if($model->save())
           {
             Yii::$app->session->setFlash('success', $msg);
             return $this->redirect(['view', 'id' => $model->id]);
           }
-          Yii::$app->session->setFlash('error', 'Server failed to be updated ['.implode(", ", $model->errors).']');
+          Yii::$app->session->setFlash('error', 'Server failed to be updated ['.Html::encode(implode(", ", $model->errors)).']');
         }
 
         return $this->render('update', [
@@ -413,9 +414,9 @@ class TargetController extends \app\components\BaseController
     {
       $model=$this->findModel($id);
         if($model->destroy())
-          Yii::$app->session->setFlash('success', 'Container destroyed from docker server [<code>'.$model->server.'</code>]');
+          Yii::$app->session->setFlash('success', 'Container destroyed from docker server [<code>'.Html::encode($model->server).'</code>]');
         else
-          Yii::$app->session->setFlash('error', 'Failed to destroy container from docker server [<code>'.$model->server.'</code>]');
+          Yii::$app->session->setFlash('error', 'Failed to destroy container from docker server [<code>'.Html::encode($model->server).'</code>]');
 
         return $this->goBack(Yii::$app->request->referrer);
     }
@@ -436,17 +437,17 @@ class TargetController extends \app\components\BaseController
           $models=Target::find()->all();
           foreach($models as $model)
             $model->spin();
-          \Yii::$app->getSession()->setFlash('success', 'Containers succesfuly restarted');
+          \Yii::$app->getSession()->setFlash('success', 'Containers successfully restarted');
         }
         else
         {
           $this->findModel($id)->spin();
-          \Yii::$app->getSession()->setFlash('success', 'Container succesfuly restarted');
+          \Yii::$app->getSession()->setFlash('success', 'Container successfully restarted');
         }
       }
       catch(\Exception $e)
       {
-        \Yii::$app->getSession()->setFlash('error', 'Failed to restart container. '.$e->getMessage());
+        \Yii::$app->getSession()->setFlash('error', 'Failed to restart container. '.Html::encode($e->getMessage()));
       }
       return $this->goBack(Yii::$app->request->referrer);
     }
@@ -465,14 +466,14 @@ class TargetController extends \app\components\BaseController
           $models=Target::find()->all();
           foreach($models as $model)
             $model->pull();
-          \Yii::$app->getSession()->setFlash('success', 'Images pulled succesfuly');
+          \Yii::$app->getSession()->setFlash('success', 'Images pulled successfully');
           return $this->redirect(['index']);
 
         }
         else
         {
           if($this->findModel($id)->pull())
-            \Yii::$app->getSession()->setFlash('success', 'Image succesfuly pulled');
+            \Yii::$app->getSession()->setFlash('success', 'Image successfully pulled');
           else
           {
             \Yii::$app->getSession()->setFlash('error', 'Failed to pull container image');

--- a/backend/modules/infrastructure/controllers/TargetInstanceAuditController.php
+++ b/backend/modules/infrastructure/controllers/TargetInstanceAuditController.php
@@ -9,6 +9,7 @@ use yii\web\Controller;
 use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
 
 /**
  * TargetInstanceAuditController implements the CRUD actions for TargetInstanceAudit model.
@@ -61,7 +62,7 @@ class TargetInstanceAuditController extends \app\components\BaseController
         }
         catch(\Exception $e)
         {
-            Yii::$app->session->setFlash('error', "Failed to delete audit records. <b>".$e->getMessage().'</b>');
+            Yii::$app->session->setFlash('error', "Failed to delete audit records. <b>".Html::encode($e->getMessage()).'</b>');
         }
         return $this->redirect(['index']);
     }

--- a/backend/modules/sales/models/PlayerCustomerSearch.php
+++ b/backend/modules/sales/models/PlayerCustomerSearch.php
@@ -5,6 +5,7 @@ namespace app\modules\sales\models;
 use yii\base\Model;
 use yii\data\ActiveDataProvider;
 use app\modules\frontend\models\Player;
+use yii\helpers\Html;
 
 /**
  * PlayerSearch represents the model behind the search form of `app\modules\frontend\models\Player`.
@@ -86,7 +87,7 @@ class PlayerCustomerSearch extends Player
           if(\Yii::$app instanceof \yii\console\Application)
             printf("Imported customer_id: %s for user %s with email %s\n",$player->stripe_customer_id,$player->username,$player->email);
           else
-            \Yii::$app->session->addFlash('success', sprintf('Imported customer_id: <b>%s</b> for user <b>%s</b> with email <b>%s</b>',$player->stripe_customer_id,$player->username,$player->email));
+            \Yii::$app->session->addFlash('success', sprintf('Imported customer_id: <b>%s</b> for user <b>%s</b> with email <b>%s</b>',Html::encode($player->stripe_customer_id),Html::encode($player->username,$player->email)));
         }
       }
     }

--- a/backend/modules/sales/models/PlayerSubscription.php
+++ b/backend/modules/sales/models/PlayerSubscription.php
@@ -7,6 +7,7 @@ use app\modules\frontend\models\Player;
 use app\modules\gameplay\models\NetworkPlayer;
 use yii\behaviors\TimestampBehavior;
 use yii\db\Expression;
+use yii\helpers\Html;
 
 /**
  * This is the model class for table "player_subscription".
@@ -135,7 +136,7 @@ class PlayerSubscription extends \yii\db\ActiveRecord
             if(\Yii::$app instanceof \yii\console\Application)
               printf("Failed to save subscription: %s\n",$stripe_subscription->id);
             else
-              \Yii::$app->session->addFlash('error', sprintf('Failed to save subscription: %s',$stripe_subscription->id));
+              \Yii::$app->session->addFlash('error', sprintf('Failed to save subscription: %s',Html::encode($stripe_subscription->id)));
           }
           else
           {
@@ -143,7 +144,7 @@ class PlayerSubscription extends \yii\db\ActiveRecord
             if(\Yii::$app instanceof \yii\console\Application)
               printf("Imported subscription: %s for player %s\n",$stripe_subscription->id,$player->username);
             else
-              \Yii::$app->session->addFlash('success', sprintf('Imported subscription: %s for player %s',$stripe_subscription->id,$player->username));
+              \Yii::$app->session->addFlash('success', sprintf('Imported subscription: %s for player %s',Html::encode($stripe_subscription->id),Html::encode($player->username)));
           }
         }
       }

--- a/backend/modules/sales/models/Product.php
+++ b/backend/modules/sales/models/Product.php
@@ -3,6 +3,7 @@
 namespace app\modules\sales\models;
 
 use Yii;
+use yii\helpers\Html;
 
 /**
  * This is the model class for table "product".
@@ -138,14 +139,14 @@ class Product extends \yii\db\ActiveRecord
           if(\Yii::$app instanceof \yii\console\Application)
             printf("Failed to save product: %s, %s\n",$stripeProduct->id,$stripeProduct->name);
           else
-            \Yii::$app->session->addFlash('error', sprintf('Failed to save product: %s, %s',$stripeProduct->id,$stripeProduct->name));
+            \Yii::$app->session->addFlash('error', sprintf('Failed to save product: %s, %s',Html::encode($stripeProduct->id),Html::encode($stripeProduct->name)));
         }
         else
         {
           if(\Yii::$app instanceof \yii\console\Application)
             printf("Imported product: %s, %s\n",$stripeProduct->id,$stripeProduct->name);
           else
-            \Yii::$app->session->addFlash('success', sprintf('Imported product: %s, %s',$stripeProduct->id,$stripeProduct->name));
+            \Yii::$app->session->addFlash('success', sprintf('Imported product: %s, %s',Html::encode($stripeProduct->id),Html::encode($stripeProduct->name)));
         }
         if(!empty($stripeProduct->metadata->network_ids))
         {


### PR DESCRIPTION
This PR attempts to fix issue #792
Furthermore, the fix is also applied in all backend flash messages by introducing `Html::escape()`