### PR TITLE
only do api GET when Notifications or Hints exist

### DIFF
--- a/backend/migrations-init/m220102_214745_populate_url_routes.php
+++ b/backend/migrations-init/m220102_214745_populate_url_routes.php
@@ -73,6 +73,7 @@ class m220102_214745_populate_url_routes extends Migration
       'networks' => 'network/default/index',
       'network/<id:\d+>' => 'network/default/view',
       'api/headshots' => 'api/headshot/index',
+      'api/notification' => 'api/notification/index',
       'subscriptions' => 'subscription/default/index',
       'subscription/success'=>'subscription/default/success',
       'subscription/create-checkout-session'=>'subscription/default/create-checkout-session',

--- a/backend/migrations/m230109_180919_add_api_notification_url_route.php
+++ b/backend/migrations/m230109_180919_add_api_notification_url_route.php
@@ -1,0 +1,40 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230109_180919_add_api_notification_url_route
+ */
+class m230109_180919_add_api_notification_url_route extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->upsert('url_route',['source'=>'api/notification','destination'=>'api/notification/index','weight'=>641]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        echo "m230109_180919_add_api_notification_url_route cannot be reverted.\n";
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m230109_180919_add_api_notification_url_route cannot be reverted.\n";
+
+        return false;
+    }
+    */
+}

--- a/frontend/modules/api/controllers/NotificationController.php
+++ b/frontend/modules/api/controllers/NotificationController.php
@@ -18,20 +18,28 @@ class NotificationController extends \yii\rest\ActiveController
   public function behaviors()
   {
     return ArrayHelper::merge(parent::behaviors(), [
+      'content'=>[
+        'class' => yii\filters\ContentNegotiator::class,
+        'formats' => [
+          'application/json' => \yii\web\Response::FORMAT_JSON,
+        ],
+      ],
       'access' => [
         'class' => AccessControl::class,
         'rules' => [
           [
             'allow' => true,
-            'roles' => ['@']
+            'roles' => ['@'],
+            'matchCallback'=> function() {
+              if(!Yii::$app->request->isAjax)
+                return false;
+              return true;
+            }
           ],
         ],
-      ],
-      [
-        'class' => 'yii\filters\ContentNegotiator',
-        'formats' => [
-          'application/json' => \yii\web\Response::FORMAT_JSON,
-        ],
+        'denyCallback' => function () {
+          return \Yii::$app->getResponse()->redirect([Yii::$app->sys->default_homepage]);
+        }
       ],
     ]);
   }
@@ -39,7 +47,6 @@ class NotificationController extends \yii\rest\ActiveController
   public function actions()
   {
     $actions = parent::actions();
-
     // disable the "delete", "create", "view","update" actions
     unset($actions['delete'], $actions['create'], $actions['view'], $actions['update']);
     $actions['index']['prepareDataProvider'] = [$this, 'prepareDataProvider'];

--- a/frontend/web/js/libechoctf.js
+++ b/frontend/web/js/libechoctf.js
@@ -192,6 +192,7 @@ function apiNotifications(){
   notifTimeout=setInterval(function () {
     var request = new XMLHttpRequest();
     request.open("GET", "/api/notification");
+    request.setRequestHeader('X-Requested-With', 'XMLHttpRequest')
     request.send();
 
     request.onreadystatechange = function () {
@@ -219,7 +220,7 @@ function apiNotifications(){
           if(jsonObj.length>0) clearDropdownCounters('Notifications')
       }
     }
-  }, 3000);
+  }, 5000);
 }
 
 $(window).blur(function() {

--- a/frontend/web/js/libechoctf.js
+++ b/frontend/web/js/libechoctf.js
@@ -188,7 +188,6 @@ function clearDropdownCounters(curId){
   el.classList.remove("text-primary");
 }
 
-
 var notifTimeout;
 var intervalTimeout=5000
 
@@ -224,7 +223,7 @@ function apiNotifications(){
           if(jsonObj.length>0) clearDropdownCounters('Notifications')
       }
     }
-  }, 5000);
+  }, intervalTimeout);
 }
 
 $(document).ready(function(){

--- a/frontend/web/js/libechoctf.js
+++ b/frontend/web/js/libechoctf.js
@@ -226,4 +226,12 @@ $(window).blur(function() {
   clearTimeout(notifTimeout);
 }).focus(apiNotifications);
 
-apiNotifications();
+$.fn.extend({
+  'ifexists': function (callback) {
+      if (this.length > 0) {
+          return callback($(this));
+      }
+  }
+});
+
+$('#Notifications, #Hints').ifexists(function(elem) { apiNotifications(); })

--- a/frontend/web/js/libechoctf.js
+++ b/frontend/web/js/libechoctf.js
@@ -1,9 +1,11 @@
-/* Avoid passive event warnings */
-//jQuery.event.special.touchstart = {
-//  setup: function( _, ns, handle ) {
-//      this.addEventListener("touchstart", handle, { passive: !ns.includes("noPreventDefault") });
-//  }
-//};
+// Extend with ifexists for checking existing elements
+$.fn.extend({
+  'ifexists': function (callback) {
+      if (this.length > 0) {
+          return callback($(this));
+      }
+  }
+});
 
 /* Dummy escapeHtml implementation */
 function escapeHtml(unsafe)
@@ -188,6 +190,8 @@ function clearDropdownCounters(curId){
 
 
 var notifTimeout;
+var intervalTimeout=5000
+
 function apiNotifications(){
   notifTimeout=setInterval(function () {
     var request = new XMLHttpRequest();
@@ -223,16 +227,19 @@ function apiNotifications(){
   }, 5000);
 }
 
-$(window).blur(function() {
-  clearTimeout(notifTimeout);
-}).focus(apiNotifications);
-
-$.fn.extend({
-  'ifexists': function (callback) {
-      if (this.length > 0) {
-          return callback($(this));
+$(document).ready(function(){
+  $('#Notifications, #Hints').ifexists(function(elem) {
+    document.addEventListener('visibilitychange', function(e) {
+      if (document.visibilityState === 'hidden') {
+        clearTimeout(notifTimeout);
       }
-  }
-});
-
-$('#Notifications, #Hints').ifexists(function(elem) { apiNotifications(); })
+      else
+      {
+        // clear any existing ones
+        clearTimeout(notifTimeout);
+        $('#Notifications, #Hints').ifexists(function(elem) { apiNotifications(); })
+      }
+    });
+    apiNotifications();
+  })
+})


### PR DESCRIPTION
This PR does the following
* Fixes #794
* Forces ajax requests only for notifications
* Adds URL route migrations (that we forgot to add before :man_facepalming: )
* Changes the blur even handling to make it a bit less error prone
