### PR TITLE
Writeup Logic modifications

### DIFF
--- a/frontend/modules/target/controllers/WriteupController.php
+++ b/frontend/modules/target/controllers/WriteupController.php
@@ -183,6 +183,13 @@ class WriteupController extends \app\components\BaseController
     public function actionEnable(int $id)
     {
         $writeups=Writeup::find()->where(['target_id'=>$id]);
+        $player_headshots=intval(Headshot::find()->where(['player_id'=>Yii::$app->user->id])->count());
+        $player_writeups=intval(PTH::find()->where(['player_id'=>Yii::$app->user->id])->count());
+        if($player_writeups>=($player_headshots+2))
+        {
+          Yii::$app->session->setFlash('error', \Yii::t('app','You have activated too many writeups, headshot some of the targets first.'));
+          return $this->redirect(['default/view','id'=>$id]);
+        }
         if((int)$writeups->count()===0)
         {
           Yii::$app->session->setFlash('error', \Yii::t('app','There are no writeups for this target.'));

--- a/frontend/themes/material/modules/target/views/default/_target_description.php
+++ b/frontend/themes/material/modules/target/views/default/_target_description.php
@@ -5,20 +5,6 @@ use app\modules\target\models\PlayerTargetHelp as PTH;
 ?>
 <div class="card terminal">
   <div class="card-body">
-    <?php if(!Yii::$app->user->isGuest && count($target->writeups)>0 && PTH::findOne(['player_id'=>Yii::$app->user->id,'target_id'=>$target->id])===null && !($identity->player_id===Yii::$app->user->id && $target->progress==100)):?>
-    <?=Html::a(
-      '<i class="fas fa-question-circle" style="font-size: 1.5em;"></i> '.\Yii::t('app','Writeups available.'),
-        ['/target/writeup/enable', 'id'=>$target->id],
-        [
-          'style'=>"font-size: 1.0em;",
-          'title' => \Yii::t('app','Request access to writeups'),
-          'rel'=>"tooltip",
-          'data-pjax' => '0',
-          'data-method' => 'POST',
-          'data-confirm'=>\Yii::t('app','Are you sure you want to enable access to writeups for this target? Any remaining flags will have their points reduced by 50%.'),
-          'aria-label'=>\Yii::t('app','Request access to writeups'),
-        ]
-    )?><br/><?php endif;?>
     <?=$target->description?>
     <?=$this->render('_target_metadata',['target'=>$target,'identity'=>$identity]);?>
     <?=$this->render('_target_migration_schedule',['scheduled'=>$target->scheduled,'network'=>$target->network]);?>

--- a/frontend/themes/material/modules/target/views/default/_target_writeups.php
+++ b/frontend/themes/material/modules/target/views/default/_target_writeups.php
@@ -25,7 +25,22 @@ use yii\helpers\Html;
           $item_classes[]='text-bold';
           $item_classes[]='active';
         }
-        echo Html::a($item->player->username.' <span class="badge badge-primary badge-pill">'.\Yii::t('app',$item->averageRatingName).'</span>',['/target/writeup/read','target_id'=>$item->target_id,'id'=>$item->id],['class'=>implode(' ',$item_classes)]);
+        if($writeups_activated)
+          echo Html::a($item->player->username.' <span class="badge badge-primary badge-pill">'.\Yii::t('app',$item->averageRatingName).'</span>',['/target/writeup/read','target_id'=>$item->target_id,'id'=>$item->id],['class'=>implode(' ',$item_classes)]);
+        else
+          echo Html::a(
+            $item->player->username.' <span class="badge badge-primary badge-pill">'.\Yii::t('app',$item->averageRatingName).'</span>',
+            //'<i class="fas fa-question-circle" style="font-size: 1.5em;"></i> '.\Yii::t('app','Writeups available.'),
+            ['/target/writeup/enable', 'id'=>$item->target_id],
+            [
+              'class'=>implode(' ',$item_classes),
+              'title' => \Yii::t('app','Request access to writeups'),
+              'data-pjax' => '0',
+              'data-method' => 'POST',
+              'data-confirm'=>\Yii::t('app','Are you sure you want to enable access to writeups for this target? Any remaining flags will have their points reduced by 50%.'),
+              'aria-label'=>\Yii::t('app','Request access to writeups'),
+            ]
+            );
       }
       ?>
     </div>

--- a/frontend/themes/material/modules/target/views/default/_versus.php
+++ b/frontend/themes/material/modules/target/views/default/_versus.php
@@ -145,8 +145,8 @@ if($headshot)
     <div class="col-lg-4 col-md-6 col-sm-6">
       <?=$this->render('_headshots_card',['target'=>$target]);?>
 
-      <?php if(count($target->writeups)>0 && (PTH::findOne(['player_id'=>Yii::$app->user->id,'target_id'=>$target->id])!==null || ($identity->player_id===Yii::$app->user->id && $target->progress==100))):?>
-      <?=$this->render('_target_writeups',['writeups'=>$target->writeups,'active'=>false]);?>
+      <?php if(count($target->writeups)>0):?>
+      <?=$this->render('_target_writeups',['writeups'=>$target->writeups,'active'=>false,'writeups_activated'=>(PTH::findOne(['player_id'=>Yii::$app->user->id,'target_id'=>$target->id])!==null || ($identity->player_id===Yii::$app->user->id && $target->progress==100))]);?>
       <?php endif;?>
     </div>
   </div>

--- a/frontend/themes/material/modules/target/views/writeup/read.php
+++ b/frontend/themes/material/modules/target/views/writeup/read.php
@@ -47,7 +47,7 @@ if($goback==='/')
       </div><!--//col-->
       <div class="col-md-4">
         <?=$this->render('../default/_target_card',['target'=>$model->target,'identity'=>Yii::$app->user->identity->profile]);?>
-        <?=$this->render('../default/_target_writeups',['writeups'=>$model->target->writeups,'active'=>$model->id]);?>
+        <?=$this->render('../default/_target_writeups',['writeups'=>$model->target->writeups,'active'=>$model->id, 'writeups_activated'=>true]);?>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR does the following
* Makes writeups listing available to players even when not active (fixes #823)
* Fail writeup activation when `writeups>=(headshots+2)` (fixes #836)
* Remove the activate writeups link from target description