### PR TITLE
Findings before claim

### DIFF
--- a/backend/migrations/m230307_091159_add_require_findings_column_to_target_table.php
+++ b/backend/migrations/m230307_091159_add_require_findings_column_to_target_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles adding columns to table `{{%target}}`.
+ */
+class m230307_091159_add_require_findings_column_to_target_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{%target}}', 'require_findings', $this->boolean()->defaultValue(0));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{%target}}', 'require_findings');
+    }
+}

--- a/backend/modules/gameplay/models/TargetAR.php
+++ b/backend/modules/gameplay/models/TargetAR.php
@@ -36,6 +36,7 @@ use app\modules\infrastructure\models\TargetMetadata;
  * @property bool $healthcheck
  * @property bool $writeup_allowed
  * @property bool $instance_allowed
+ * @property bool $require_findings
  * @property string $created_at The date this record was created_at
  *
  * @property Finding[] $findings
@@ -71,7 +72,7 @@ class TargetAR extends \yii\db\ActiveRecord
         return [
             [['parameters', 'description','imageparams'], 'string'],
             [['name', 'fqdn'], 'required'],
-            [['ip', 'timer','active', 'rootable', 'difficulty', 'suggested_xp', 'required_xp','weight','healthcheck','writeup_allowed','player_spin','headshot_spin','instance_allowed'], 'integer'],
+            [['ip', 'timer','active', 'rootable', 'difficulty', 'suggested_xp', 'required_xp','weight','healthcheck','writeup_allowed','player_spin','headshot_spin','instance_allowed','require_findings'], 'integer'],
             [['ipoctet'], 'ip'],
             [['name', 'fqdn', 'purpose', 'net', 'server', 'image', 'dns','category'], 'string', 'max' => 255],
             [['image'], 'filter', 'filter'=>'strtolower'],

--- a/backend/modules/gameplay/models/TargetSearch.php
+++ b/backend/modules/gameplay/models/TargetSearch.php
@@ -20,7 +20,7 @@ class TargetSearch extends Target
     public function rules()
     {
         return [
-            [['id', 'ip', 'timer','rootable', 'difficulty', 'required_xp', 'suggested_xp','headshot','weight','pts','instance_allowed'], 'integer'],
+            [['id', 'ip', 'timer','rootable', 'difficulty', 'required_xp', 'suggested_xp','headshot','weight','pts','instance_allowed','require_findings'], 'integer'],
             ['active','boolean'],
             [['headshot'],'default','value'=>null ],
             [['status'], 'in', 'range' => ['online', 'offline', 'powerup', 'powerdown', 'maintenance']],
@@ -72,6 +72,7 @@ class TargetSearch extends Target
             'target.active' => $this->active,
             'rootable' => $this->rootable,
             'instance_allowed' => $this->instance_allowed,
+            'require_findings' => $this->require_findings,
             'difficulty' => $this->difficulty,
             'suggested_xp' => $this->suggested_xp,
             'required_xp' => $this->required_xp,

--- a/backend/modules/infrastructure/views/target/_form.php
+++ b/backend/modules/infrastructure/views/target/_form.php
@@ -64,6 +64,9 @@ use yii\bootstrap5\ActiveForm;
           <?= $form->field($model, 'instance_allowed')->checkbox()->hint('Whether or not private instances are allowed for the target (checked=allowed)') ?>
         </div>
         <div class="col-md-2">
+          <?= $form->field($model, 'require_findings')->checkbox()->hint('Whether or not findings are required before claiming flags. <small>This value is bypassed by <code>force_findings_to_claim</code> sysconfig key.</small>(checked=required)') ?>
+        </div>
+        <div class="col-md-2">
           <?= $form->field($model, 'player_spin')->checkbox()->hint('Allow players to spin targets?') ?>
         </div>
         <div class="col-md-2">

--- a/backend/modules/infrastructure/views/target/index.php
+++ b/backend/modules/infrastructure/views/target/index.php
@@ -66,6 +66,7 @@ yii\bootstrap5\Modal::end();
       'scheduled_at:dateTime:Scheduled',
       'rootable:boolean',
       'instance_allowed:boolean:Instances',
+      'require_findings:boolean:Req. Findings',
       'active:boolean',
       'timer:boolean',
       [

--- a/backend/modules/infrastructure/views/target/view.php
+++ b/backend/modules/infrastructure/views/target/view.php
@@ -75,6 +75,7 @@ $this->params['breadcrumbs'][]=$this->title;
             'headshot_spin:boolean',
             'player_spin:boolean',
             'instance_allowed:boolean',
+            'require_findings:boolean',
             'status',
             'scheduled_at',
             'purpose',

--- a/docs/Sysconfig-Keys.md
+++ b/docs/Sysconfig-Keys.md
@@ -15,6 +15,7 @@
 * `target_hide_inactive`: Hide inactive targets from the frontend listings. This includes upcoming powerups
 * `network_view_guest`: Allow networks to be viewed by guests
 * `monthly_leaderboards`: Enable monthly player related leaderboards
+* `force_findings_to_claim`: Enable the enforcement of players needing to have discovered the findings before claiming flags
 
 Not activated by default on current code-base but are going to
 * _`require_activation`_ Whether it is required for users to activate their accounts

--- a/frontend/modules/target/models/TargetAR.php
+++ b/frontend/modules/target/models/TargetAR.php
@@ -108,6 +108,7 @@ class TargetAR extends \app\models\ActiveRecordReadOnly
             'player_spin'=> AttributeTypecastBehavior::TYPE_BOOLEAN,
             'headshot_spin'=> AttributeTypecastBehavior::TYPE_BOOLEAN,
             'instance_allowed'=> AttributeTypecastBehavior::TYPE_BOOLEAN,
+            'require_findings'=> AttributeTypecastBehavior::TYPE_BOOLEAN,
             'difficulty' => AttributeTypecastBehavior::TYPE_INTEGER,
             'weight' => AttributeTypecastBehavior::TYPE_INTEGER,
             'on_ondemand' => AttributeTypecastBehavior::TYPE_BOOLEAN,
@@ -130,7 +131,7 @@ class TargetAR extends \app\models\ActiveRecordReadOnly
       return [
         [['description'], 'string'],
         [['ip'], 'required'],
-        [['ip', 'active', 'rootable', 'difficulty', 'suggested_xp', 'required_xp','weight','timer','writeup_allowed','player_spin','headshot_spin','instance_allowed'], 'integer'],
+        [['ip', 'active', 'rootable', 'difficulty', 'suggested_xp', 'required_xp','weight','timer','writeup_allowed','player_spin','headshot_spin','instance_allowed','require_findings'], 'integer'],
         [['scheduled_at', 'ts'], 'safe'],
         [['name', 'fqdn', 'purpose', 'net', 'server', 'image', 'dns', 'parameters'], 'string', 'max' => 255],
         [['mac'], 'string', 'max' => 30],

--- a/frontend/modules/target/models/TargetPlayerState.php
+++ b/frontend/modules/target/models/TargetPlayerState.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace app\modules\target\models;
+
+use Yii;
+
+/**
+ * This is the model class for table "target_player_state".
+ *
+ * @property int $id
+ * @property int $player_id
+ * @property int $player_treasures
+ * @property int $player_findings
+ * @property int $player_points
+ *
+ * @property Target $target
+ * @property Player $player
+ */
+class TargetPlayerState extends \yii\db\ActiveRecord
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function tableName()
+    {
+        return 'target_player_state';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rules()
+    {
+        return [
+            [['id', 'player_id'], 'required'],
+            [['id', 'player_id', 'player_treasures', 'player_findings', 'player_points'], 'integer'],
+            [['id', 'player_id'], 'unique', 'targetAttribute' => ['id', 'player_id']],
+            [['id'], 'exist', 'skipOnError' => true, 'targetClass' => Target::class, 'targetAttribute' => ['id' => 'id']],
+            [['player_id'], 'exist', 'skipOnError' => true, 'targetClass' => Player::class, 'targetAttribute' => ['player_id' => 'id']],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function attributeLabels()
+    {
+        return [
+            'id' => Yii::t('app', 'ID'),
+            'player_id' => Yii::t('app', 'Player ID'),
+            'player_treasures' => Yii::t('app', 'Player Treasures'),
+            'player_findings' => Yii::t('app', 'Player Findings'),
+            'player_points' => Yii::t('app', 'Player Points'),
+        ];
+    }
+
+    /**
+     * Gets query for [[Id0]].
+     *
+     * @return \yii\db\ActiveQuery|TargetQuery
+     */
+    public function getTarget()
+    {
+        return $this->hasOne(Target::class, ['id' => 'id']);
+    }
+
+    /**
+     * Gets query for [[Player]].
+     *
+     * @return \yii\db\ActiveQuery|PlayerQuery
+     */
+    public function getPlayer()
+    {
+        return $this->hasOne(Player::class, ['id' => 'player_id']);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return TargetPlayerStateQuery the active query used by this AR class.
+     */
+    public static function find()
+    {
+        return new TargetPlayerStateQuery(get_called_class());
+    }
+}

--- a/frontend/modules/target/models/TargetPlayerStateQuery.php
+++ b/frontend/modules/target/models/TargetPlayerStateQuery.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace app\modules\target\models;
+
+/**
+ * This is the ActiveQuery class for [[TargetPlayerState]].
+ *
+ * @see TargetPlayerState
+ */
+class TargetPlayerStateQuery extends \yii\db\ActiveQuery
+{
+    /*public function active()
+    {
+        return $this->andWhere('[[status]]=1');
+    }*/
+
+    /**
+     * {@inheritdoc}
+     * @return TargetPlayerState[]|array
+     */
+    public function all($db = null)
+    {
+        return parent::all($db);
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return TargetPlayerState|array|null
+     */
+    public function one($db = null)
+    {
+        return parent::one($db);
+    }
+}


### PR DESCRIPTION
This PR fixes #837 by introducing
* a sysconfig key `force_findings_to_claim` which forces findings before claim for all targets
* a target boolean column `require_findings` for requiring findings before claiming flags

When a player tries to claim a flag from the _frontend_, the following checks are performed (in addition and after the existing ones)
* If either of `sysconfig:force_findings_to_claim` or `target:require_findings` is **`true`** 
* and the `target_player_state` has no record for the player & target combination
* and the target has findings>0 
* then return an error to the player and increment their `claim_no_finding` counter
