### PR TITLE
AccessControl overload and namespace path changes

### DIFF
--- a/frontend/components/BaseController.php
+++ b/frontend/components/BaseController.php
@@ -3,7 +3,7 @@
 namespace app\components;
 
 use Yii;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 
 /**
  * @property bool $eventInactive

--- a/frontend/controllers/DashboardController.php
+++ b/frontend/controllers/DashboardController.php
@@ -13,7 +13,7 @@ use app\models\PlayerScore;
 use app\models\Profile;
 use app\models\News;
 use yii\helpers\ArrayHelper;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\filters\VerbFilter;
 
 class DashboardController extends \app\components\BaseController

--- a/frontend/controllers/LegalController.php
+++ b/frontend/controllers/LegalController.php
@@ -3,7 +3,7 @@
 namespace app\controllers;
 use Yii;
 use yii\helpers\ArrayHelper;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 
 class LegalController extends \app\components\BaseController
 {

--- a/frontend/controllers/ProfileController.php
+++ b/frontend/controllers/ProfileController.php
@@ -8,7 +8,7 @@ use \app\modules\target\models\Target;
 use \app\modules\game\models\Headshot;
 use \app\modules\target\models\TargetQuery;
 use yii\helpers\ArrayHelper;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\filters\VerbFilter;
 use yii\web\NotFoundHttpException;
 use yii\web\Response;

--- a/frontend/controllers/SiteController.php
+++ b/frontend/controllers/SiteController.php
@@ -8,7 +8,7 @@ use yii\web\Response;
 use yii\web\BadRequestHttpException;
 use yii\base\InvalidArgumentException;
 use yii\filters\VerbFilter;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 use app\models\forms\LoginForm;
 use app\models\forms\SignupForm;

--- a/frontend/modules/api/controllers/NotificationController.php
+++ b/frontend/modules/api/controllers/NotificationController.php
@@ -5,7 +5,7 @@ namespace app\modules\api\controllers;
 use Yii;
 use yii\helpers\ArrayHelper;
 use yii\data\ActiveDataProvider;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\data\ActiveDataFilter;
 
 class NotificationController extends \yii\rest\ActiveController

--- a/frontend/modules/challenge/controllers/DefaultController.php
+++ b/frontend/modules/challenge/controllers/DefaultController.php
@@ -12,7 +12,7 @@ use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
 use yii\data\ActiveDataProvider;
 use app\modules\challenge\models\AnswerForm;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 
 /**

--- a/frontend/modules/game/controllers/BadgeController.php
+++ b/frontend/modules/game/controllers/BadgeController.php
@@ -4,7 +4,7 @@ namespace app\modules\game\controllers;
 
 use Yii;
 use yii\web\Controller;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 use yii\web\NotFoundHttpException;
 use app\modules\game\models\Headshot;

--- a/frontend/modules/game/controllers/DefaultController.php
+++ b/frontend/modules/game/controllers/DefaultController.php
@@ -4,7 +4,7 @@ namespace app\modules\game\controllers;
 
 use Yii;
 use yii\web\Controller;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 use yii\web\NotFoundHttpException;
 

--- a/frontend/modules/game/controllers/LeaderboardsController.php
+++ b/frontend/modules/game/controllers/LeaderboardsController.php
@@ -4,7 +4,7 @@ namespace app\modules\game\controllers;
 
 use Yii;
 use yii\data\ActiveDataProvider;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 
 class LeaderboardsController extends \app\components\BaseController

--- a/frontend/modules/help/controllers/CreditsController.php
+++ b/frontend/modules/help/controllers/CreditsController.php
@@ -3,7 +3,7 @@
 namespace app\modules\help\controllers;
 use Yii;
 use yii\helpers\ArrayHelper;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\data\ActiveDataProvider;
 use app\modules\help\models\Credits;
 class CreditsController extends \app\components\BaseController

--- a/frontend/modules/network/controllers/DefaultController.php
+++ b/frontend/modules/network/controllers/DefaultController.php
@@ -9,7 +9,7 @@ use yii\web\Controller;
 use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
 use yii\data\ActiveDataProvider;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 
 /**

--- a/frontend/modules/subscription/controllers/DefaultController.php
+++ b/frontend/modules/subscription/controllers/DefaultController.php
@@ -2,7 +2,7 @@
 namespace app\modules\subscription\controllers;
 
 use Yii;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 use yii\data\ActiveDataProvider;
 

--- a/frontend/modules/target/controllers/DefaultController.php
+++ b/frontend/modules/target/controllers/DefaultController.php
@@ -20,7 +20,7 @@ use app\modules\target\models\TargetPlayerState as TPS;
 
 use app\models\PlayerFinding;
 use app\models\PlayerTreasure;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\Html;
 use yii\helpers\Url;
 use yii\helpers\ArrayHelper;

--- a/frontend/modules/target/controllers/WriteupController.php
+++ b/frontend/modules/target/controllers/WriteupController.php
@@ -13,7 +13,7 @@ use app\modules\game\models\Headshot;
 use app\modules\target\models\Target;
 use app\modules\target\models\PlayerTargetHelp as PTH;
 use app\modules\target\models\Writeup;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\helpers\Html;
 use yii\helpers\Url;
 use yii\helpers\ArrayHelper;

--- a/frontend/modules/target/models/TreasureQuery.php
+++ b/frontend/modules/target/models/TreasureQuery.php
@@ -23,10 +23,10 @@ class TreasureQuery extends \yii\db\ActiveQuery
       }
       public function claimable()
       {
-        return $this->andWhere(new yii\db\Expression('appears!=0'));
+        return $this->andWhere(new \yii\db\Expression('appears!=0'));
       }
       public function notBy(int $player_id)
       {
-        return $this->andWhere(new yii\db\Expression('treasure.id NOT IN (SELECT treasure_id FROM player_treasure WHERE player_id='.$player_id.')'));
+        return $this->andWhere(new \yii\db\Expression('treasure.id NOT IN (SELECT treasure_id FROM player_treasure WHERE player_id='.$player_id.')'));
       }
 }

--- a/frontend/modules/team/Module.php
+++ b/frontend/modules/team/Module.php
@@ -2,7 +2,7 @@
 
 namespace app\modules\team;
 
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use yii\web\NotFoundHttpException;
 
 /**

--- a/frontend/modules/tutorial/controllers/DefaultController.php
+++ b/frontend/modules/tutorial/controllers/DefaultController.php
@@ -7,7 +7,7 @@ use yii\web\Controller;
 use yii\web\NotFoundHttpException;
 use yii\filters\VerbFilter;
 use yii\data\ActiveDataProvider;
-use yii\filters\AccessControl;
+use app\overloads\yii\filters\AccessControl;
 use app\modules\tutorial\models\Tutorial;
 use app\modules\tutorial\models\TutorialTask;
 use yii\helpers\ArrayHelper;

--- a/frontend/overloads/yii/filters/AccessControl.php
+++ b/frontend/overloads/yii/filters/AccessControl.php
@@ -1,0 +1,33 @@
+<?php
+namespace app\overloads\yii\filters;
+
+use Yii;
+use yii\web\ForbiddenHttpException;
+
+/**
+ * AccessControl Overloads the Yii2 default so that we can control the default error message
+ *
+ * @author Pantelis Roditis <proditis@echothrust.com>
+ * @since 0.23.0
+ */
+class AccessControl extends \yii\filters\AccessControl
+{
+    /**
+     * Denies the access of the user.
+     * The default implementation will redirect the user to the login page if he is a guest;
+     * if the user is already logged, a 403 HTTP exception will be thrown.
+     * @param User|false $user the current user or boolean `false` in case of detached User component
+     * @throws ForbiddenHttpException if the user is already logged in or in case of detached User component.
+     */
+    protected function denyAccess($user)
+    {
+        if ($user !== false && $user->getIsGuest()) {
+            $user->loginRequired();
+        } else {
+            Yii::$app->session->setFlash('warning',Yii::t('yii', 'You are not allowed to perform this action.'));
+            Yii::$app->response->redirect(Yii::$app->request->referrer ?: [Yii::$app->sys->default_homepage])->send();
+            return;
+            throw new ForbiddenHttpException(Yii::t('yii', 'You are not allowed to perform this action.'));
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the following frontend changes:
* Introduces an AccessControl model overload to redirect the logged in users and show a notification instead of showing error page
* Incorporates the new AccessControl into the frontend controllers
* Added full namespace path for db expressions on TreasureQuery