### PR TITLE
Update notification rotation logic and management

### DIFF
--- a/backend/components/columns/BooleanColumn.php
+++ b/backend/components/columns/BooleanColumn.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace app\components\columns;
+
+use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
+use yii\base\InvalidConfigException;
+/**
+ * Column for boolean value
+ * [[attribute]] Reflects to the attribute name expected from the model
+ */
+
+class BooleanColumn extends \yii\grid\DataColumn
+{
+  public function init()
+  {
+    parent::init();
+    $this->format = "html";
+    if (!$this->attribute) {
+      throw new InvalidConfigException('No {attribute} provided.');
+    }
+
+    $this->filterAttribute = $this->attribute;
+  }
+
+  protected function renderDataCellContent($model, $key, $index)
+  {
+    $value=(bool) ArrayHelper::getValue($model, $this->attribute);
+    if ($this->content === null) {
+      if($value)
+        return $this->grid->formatter->format('<i class="fas fa-check text-active"></i>', $this->format);
+      return $this->grid->formatter->format('<i class="fas fa-times text-danger"></i>', $this->format);
+    }
+    return parent::renderDataCellContent($model, $key, $index);
+  }
+}

--- a/backend/migrations/m230322_215400_create_rotate_notifications_procedure.php
+++ b/backend/migrations/m230322_215400_create_rotate_notifications_procedure.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230322_220536_create_rotate_notifications_procedure
+ */
+class m230322_215400_create_rotate_notifications_procedure extends Migration
+{
+    public $DROP_SQL = "DROP PROCEDURE IF EXISTS {{%rotate_notifications}}";
+    public $CREATE_SQL = "CREATE PROCEDURE {{%rotate_notifications}} (IN archived_interval_minute INT, IN pending_interval_minute INT)
+    BEGIN
+      DELETE FROM `notification` WHERE
+        (`archived`=1 AND DATE(`updated_at`) < NOW() - INTERVAL archived_interval_minute MINUTE) OR
+        (created_at IS null AND updated_at IS null) OR
+        (title LIKE '%target%' and DATE(created_at) < NOW() - INTERVAL pending_interval_minute MINUTE);
+    END";
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+        $this->db->createCommand($this->DROP_SQL)->execute();
+        $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+        $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m230322_215432_update_rotate_notifications_event.php
+++ b/backend/migrations/m230322_215432_update_rotate_notifications_event.php
@@ -11,10 +11,9 @@ class m230322_215432_update_rotate_notifications_event extends Migration
   public $CREATE_SQL = "CREATE EVENT {{%rotate_notifications}} ON SCHEDULE EVERY 12 HOUR STARTS date_format(now(),'%Y-%m-%d 00:00:01') ON COMPLETION PRESERVE ENABLE DO
     BEGIN
       ALTER EVENT {{%rotate_notifications}} DISABLE;
-      DELETE FROM `notification` WHERE
-        (`archived`=1 AND date(`updated_at`) < NOW() - INTERVAL 3 HOUR) OR
-        (created_at is null and updated_at is null) OR
-        (title like '%target%' and date(`created_at`) < now() - interval 3 day);
+      -- Rotate archived notifications older than 3 hours (180)
+      -- pending target after 3 days ((24*3)*60)
+      CALL rotate_notifications(180,(24*3)*60);
       ALTER EVENT {{%rotate_notifications}} ENABLE;
     END";
 

--- a/backend/migrations/m230322_215432_update_rotate_notifications_event.php
+++ b/backend/migrations/m230322_215432_update_rotate_notifications_event.php
@@ -1,0 +1,31 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230322_215432_update_rotate_notifications_event
+ */
+class m230322_215432_update_rotate_notifications_event extends Migration
+{
+  public $DROP_SQL = "DROP EVENT IF EXISTS {{%rotate_notifications}}";
+  public $CREATE_SQL = "CREATE EVENT {{%rotate_notifications}} ON SCHEDULE EVERY 12 HOUR STARTS date_format(now(),'%Y-%m-%d 00:00:01') ON COMPLETION PRESERVE ENABLE DO
+    BEGIN
+      ALTER EVENT {{%rotate_notifications}} DISABLE;
+      DELETE FROM `notification` WHERE
+        (`archived`=1 AND date(`updated_at`) < NOW() - INTERVAL 3 HOUR) OR
+        (created_at is null and updated_at is null) OR
+        (title like '%target%' and date(`created_at`) < now() - interval 3 day);
+      ALTER EVENT {{%rotate_notifications}} ENABLE;
+    END";
+
+  public function up()
+  {
+    $this->db->createCommand($this->DROP_SQL)->execute();
+    $this->db->createCommand($this->CREATE_SQL)->execute();
+  }
+
+  public function down()
+  {
+    $this->db->createCommand($this->DROP_SQL)->execute();
+  }
+}

--- a/backend/modules/activity/controllers/NotificationController.php
+++ b/backend/modules/activity/controllers/NotificationController.php
@@ -133,6 +133,31 @@ class NotificationController extends \app\components\BaseController
   }
 
   /**
+   * Rotates notifications
+   * @param integer $id
+   * @return mixed
+   * @throws NotFoundHttpException if the model cannot be found
+   */
+  public function actionRotate($archived_interval_minute=180, $pending_interval_minute=4320)
+  {
+    try {
+      $affected=(int) Yii::$app->db->createCommand("CALL rotate_notifications(:archived_interval_minute,:pending_interval_minute)")
+                  ->bindValue(':archived_interval_minute',180)
+                  ->bindValue(':pending_interval_minute',4320)
+                  ->execute();
+      if($affected>0)
+        Yii::$app->session->setFlash('success',Yii::t('app','Deleted {n,plural,=0{no notifications} =1{one notification} other{# notifications}}.',['n'=>$affected]));
+      else
+        Yii::$app->session->setFlash('info',Yii::t('app',"No notifications found to rotate."));
+
+    } catch (\Exception $e)
+    {
+      Yii::$app->session->setFlash('error',Html::encode($e->getMessage()));
+    }
+    return $this->redirect(['index']);
+  }
+
+  /**
    * Finds the Notification model based on its primary key value.
    * If the model is not found, a 404 HTTP exception will be thrown.
    * @param integer $id

--- a/backend/modules/activity/views/notification/index.php
+++ b/backend/modules/activity/views/notification/index.php
@@ -7,43 +7,57 @@ use yii\grid\GridView;
 /* @var $searchModel app\modules\activity\models\NotificationSearch */
 /* @var $dataProvider yii\data\ActiveDataProvider */
 
-$this->title='Notifications';
-$this->params['breadcrumbs'][]=['label' => 'Notifications', 'url' => ['index']];
+$this->title = 'Notifications';
+$this->params['breadcrumbs'][] = ['label' => 'Notifications', 'url' => ['index']];
 yii\bootstrap5\Modal::begin([
-    'title' => '<h2><i class="bi bi-info-circle-fill"></i> '.Html::encode($this->title).' Help</h2>',
-    'toggleButton' => ['label' => '<i class="bi bi-info-circle-fill"></i> Help','class'=>'btn btn-info'],
+  'title' => '<h2><i class="bi bi-info-circle-fill"></i> ' . Html::encode($this->title) . ' Help</h2>',
+  'toggleButton' => ['label' => '<i class="bi bi-info-circle-fill"></i> Help', 'class' => 'btn btn-info'],
 ]);
-echo yii\helpers\Markdown::process($this->render('help/'.$this->context->action->id), 'gfm');
+echo yii\helpers\Markdown::process($this->render('help/' . $this->context->action->id), 'gfm');
 yii\bootstrap5\Modal::end();
 ?>
 <div class="notification-index">
 
-    <h1><?= Html::encode($this->title) ?></h1>
+  <h1><?= Html::encode($this->title) ?></h1>
 
-    <p>
-        <?= Html::a('Create Notification', ['create'], ['class' => 'btn btn-success']) ?>
-    </p>
+  <p>
+    <?= Html::a('Create', ['create'], ['class' => 'btn btn-success', 'data-toggle' => 'tooltip', 'title' => 'Create a new notification']) ?>
+    <?= Html::a('Rotate', ['rotate'], [
+      'class' => 'btn btn-warning',
+      'data-toggle' => 'tooltip',
+      'title' => 'Rotate old notifications',
+      'data' => [
+        'confirm' => Yii::t('app', 'This clears archived and pending notifications using the default settings of 180 minutes for the archived and 3 days for pending notifications about target operations.'),
+      ],
+    ]) ?>
+  </p>
 
-    <?php // echo $this->render('_search', ['model' => $searchModel]); ?>
+  <?= GridView::widget([
+    'dataProvider' => $dataProvider,
+    'filterModel' => $searchModel,
+    'rowOptions'=>['class'=>'align-middle'],
+    'columns' => [
 
-    <?= GridView::widget([
-        'dataProvider' => $dataProvider,
-        'filterModel' => $searchModel,
-        'columns' => [
+      'id',
+      ['class' => 'app\components\columns\ProfileColumn', 'attribute' => 'player'],
+      'category',
+      'title',
+      [
+        'class' => 'app\components\columns\BooleanColumn',
+        'attribute' => 'archived',
+        'contentOptions'=>['class'=>'text-center fs-5'],
+        'filter' => ['1' => 'Archived ', '0' => 'Pending ']
+      ],
+      [
+        'attribute' => 'created_at',
+        'format'=>'raw',
+        'value'=>function($model){return Html::tag('abbr',Yii::$app->formatter->asRelativeTime($model->created_at),['title'=>$model->created_at]);}
+      ],
+      //'updated_at',
 
-            'id',
-            'player_id',
-            ['class' => 'app\components\columns\ProfileColumn','attribute'=>'player'],
-            'category',
-            'title',
-            'body:html',
-            'archived',
-            'created_at',
-            'updated_at',
-
-            ['class' => 'yii\grid\ActionColumn'],
-        ],
-    ]);?>
+      ['class' => 'yii\grid\ActionColumn'],
+    ],
+  ]); ?>
 
 
 </div>


### PR DESCRIPTION
The following PR does the following:
* Changes the logic of notification rotations to rotate archived older than 3 hours and non archived ones with regards to targets after 3 days
* Creates a mysql procedure `rotate_notifications` which takes parameters the archived interval and non archived targets interval
* Updates the existing event to call the procedure instead
* Adds a rotate action to backend notifications controller
* Updates the backend notification gridview