### PR TITLE
Maintenance notification

### DIFF
--- a/docs/Sysconfig-Keys.md
+++ b/docs/Sysconfig-Keys.md
@@ -17,6 +17,7 @@
 * `monthly_leaderboards`: Enable monthly player related leaderboards
 * `force_findings_to_claim`: Enable the enforcement of players needing to have discovered the findings before claiming flags
 * `maintenance`: Enable site-wide maintenance mode
+* `maintenance_notification`: Send maintenance notification to everyone connected to the frontend interface. The popup can be dismissed but it always comes back. No other notifications are delivered.
 
 Not activated by default on current code-base but are going to
 * _`require_activation`_ Whether it is required for users to activate their accounts

--- a/frontend/assets/MaterialAsset.php
+++ b/frontend/assets/MaterialAsset.php
@@ -68,7 +68,7 @@ class MaterialAsset extends AssetBundle
     /******/
     //'/js/cookieconsent.min.js', // Move this to only the pages needing it.
     '/js/material-dashboard.js?v=0.21.0',
-    ['/js/libechoctf.js?v=0.21.0', 'defer' => 'defer'],
+    ['/js/libechoctf.js?v=0.23.0', 'defer' => 'defer'],
   ];
 
   public $depends = [

--- a/frontend/modules/api/controllers/NotificationController.php
+++ b/frontend/modules/api/controllers/NotificationController.php
@@ -60,7 +60,7 @@ class NotificationController extends \yii\rest\ActiveController
     if(Yii::$app->sys->maintenance_notification!==false)
     {
       return new ArrayDataProvider([
-        'allModels' => [['id'=>-1, 'title'=>'Platform Maintenance!', 'category'=>'swal:info', 'body'=>'The platform will go down for maintenance but will be back shortly!']],
+        'allModels' => [['id'=>-1, 'title'=>Yii::t('app','Platform Maintenance!'), 'category'=>'swal:info', 'body'=>Yii::t('app','The platform will go down for maintenance. We will be back back shortly!')]],
         'sort' => false,
         'pagination' => false,
       ]);

--- a/frontend/modules/api/controllers/NotificationController.php
+++ b/frontend/modules/api/controllers/NotificationController.php
@@ -5,8 +5,8 @@ namespace app\modules\api\controllers;
 use Yii;
 use yii\helpers\ArrayHelper;
 use yii\data\ActiveDataProvider;
+use yii\data\ArrayDataProvider;
 use app\overloads\yii\filters\AccessControl;
-use yii\data\ActiveDataFilter;
 
 class NotificationController extends \yii\rest\ActiveController
 {
@@ -57,6 +57,14 @@ class NotificationController extends \yii\rest\ActiveController
   public function prepareDataProvider()
   {
     \Yii::$app->response->format = \yii\web\Response::FORMAT_JSON;
+    if(Yii::$app->sys->maintenance_notification!==false)
+    {
+      return new ArrayDataProvider([
+        'allModels' => [['id'=>-1, 'title'=>'Platform Maintenance!', 'category'=>'swal:info', 'body'=>'The platform will go down for maintenance but will be back shortly!']],
+        'sort' => false,
+        'pagination' => false,
+      ]);
+    }
     $query = \app\models\Notification::find()->my()->pending();
     if(intval($query->count())===0)
     {

--- a/frontend/web/js/libechoctf.js
+++ b/frontend/web/js/libechoctf.js
@@ -206,8 +206,10 @@ function apiNotifications(){
             const record=jsonObj[i];
             if(record.category.startsWith('swal'))
             {
-              console.log('swal:'+record.category)
-              swal.fire({ title: record.title, text: record.body, type: record.category.replace('swal:',''), showConfirmButton: true});
+              if(!swal.isVisible())
+              {
+                swal.fire({ title: record.title, text: record.body, type: record.category.replace('swal:',''), showConfirmButton: true});
+              }
             }
             else {
               $.notify({
@@ -234,8 +236,8 @@ $(document).ready(function(){
       }
       else
       {
-        // clear any existing ones
         clearTimeout(notifTimeout);
+        // clear any existing ones
         $('#Notifications, #Hints').ifexists(function(elem) { apiNotifications(); })
       }
     });


### PR DESCRIPTION
Introduce maintenance notification for frontend. When `maintenance_notification` is set and has non 0 value, display a SweetAlert about the system going down for maintenance.
![image](https://user-images.githubusercontent.com/4373752/227767295-df2460d0-c653-454c-84cc-74a0ae2f6aa1.png)


