### PR TITLE
Regenerate the player badge when there are updates to the player

### DIFF
--- a/docs/console-commands/Frontend_Generator.md
+++ b/docs/console-commands/Frontend_Generator.md
@@ -26,12 +26,14 @@ Generate profile badge images for all active players.
 Usage: `./frontend/yii generator/all-badges [owner]`
 * `owner` optional user id to change the ownership of the generated images
 
-## badges($owner=0)
-Update the badges for players that had activity during the past 26 hours
+## badges($owner=0,$interval=86400,$limit=200)
+Update the badges for players that had activity during the past 24 hours
 
-Usage: `./frontend/yii generator/badges [owner]`
+Usage: `./frontend/yii generator/badges [owner] [interval] [limit]`
 
-* `owner` optional user id to change the ownership of the generated images
+* `owner` optional local user to change the ownership of the generated image files (default uid 0)
+* `interval` optional time in seconds to check that the badges are older than (default older than 86400 seconds)
+* `limit` limit the operation to this number of players (default 200)
 
 ## urls($domain)
 Generate all available registered URL routes on the system for easier testing of the activated endpoints.

--- a/frontend/controllers/ProfileController.php
+++ b/frontend/controllers/ProfileController.php
@@ -251,6 +251,7 @@ class ProfileController extends \app\components\BaseController
           $settingsForm->uploadedAvatar->saveAs($fname);
           $settingsForm->uploadedAvatar=null;
         }
+        $profile->genBadge();
         $settingsForm->save();
         $settingsForm->reset();
       }

--- a/frontend/controllers/ProfileController.php
+++ b/frontend/controllers/ProfileController.php
@@ -135,20 +135,23 @@ class ProfileController extends \app\components\BaseController
           ->set('Content-type', 'image/png');
 
       Yii::$app->response->format = Response::FORMAT_RAW;
-      if(file_exists(\Yii::getAlias('@app/web/images/avatars/badges/').'/'.$profile->id.'.png'))
+      $playerBadgeFname=\Yii::getAlias('@app/web/images/avatars/badges/').'/'.$profile->id.'.png';
+      if(file_exists($playerBadgeFname) && filemtime($playerBadgeFname)>(time()-86400))
       {
-        return file_get_contents(\Yii::getAlias('@app/web/images/avatars/badges/').'/'.$profile->id.'.png');
+        return file_get_contents($playerBadgeFname);
       }
+      // Clear file cache since we are about to generate the file
+      clearstatcache(true,$playerBadgeFname);
+
       try {
         $image=\app\components\Img::profile($profile);
 
         if($image==false)
           return $this->redirect(['/']);
 
-
         ob_start();
         imagepng($image);
-        imagepng($image,\Yii::getAlias('@app/web/images/avatars/badges/').'/'.$profile->id.'.png');
+        imagepng($image,$playerBadgeFname);
         imagedestroy($image);
         return ob_get_clean();
       } catch (\Exception $e) {

--- a/frontend/models/Profile.php
+++ b/frontend/models/Profile.php
@@ -198,4 +198,20 @@ class Profile extends ProfileAR
       ->bindValue(':metric',$key)
       ->queryScalar());
     }
+
+    public function genBadge()
+    {
+      try {
+        $image=\app\components\Img::profile($this);
+
+        if($image==false)
+          return false;
+
+        imagepng($image,\Yii::getAlias('@app/web/images/avatars/badges/').'/'.$this->id.'.png');
+        imagedestroy($image);
+      } catch (\Exception $e) {
+        return false;
+      }
+      return true;
+    }
 }


### PR DESCRIPTION
The following PR does the following
* [x] Regenerate badge when the player update their settings
* [x] update the `profile/badge` action to check when was the last time the badge was generated and if its older than 1 day generates it. Also clears file path cache for the given badge.
* [x] Updates the frontend/generator/badges action to regenerate when badge is older than a day


fixes #956 