### PR TITLE
Multiple updates to docs and yml

### DIFF
--- a/ansible/Dockerfiles/example/variables.yml
+++ b/ansible/Dockerfiles/example/variables.yml
@@ -1,6 +1,9 @@
 ---
 hostname: example
 fqdn: example.echocity-f.com
+ansible_host: 10.0.160.xx # The IP address for the target
+DOCKER: localhost # Docker server to start the container
+mac: de:ad:be:ef:c0:ff:ee # printf "02:42:%.2x:%.2x:%.2x:%.2x\n" 10 0 160 123
 rootable: 1 # 0 for no
 difficulty: 3 # 0-6
 player_spin: 1 # allow player spins

--- a/ansible/Dockerfiles/sanitycheck/variables.yml
+++ b/ansible/Dockerfiles/sanitycheck/variables.yml
@@ -1,6 +1,9 @@
 ---
 hostname: sanitycheck
 fqdn: sanitycheck
+ansible_host: 10.0.160.xx # The IP address for the target
+DOCKER: localhost # Docker server to start the container
+mac: de:ad:be:ef:c0:ff:ee # printf "02:42:%.2x:%.2x:%.2x:%.2x\n" 10 0 160 123
 rootable: 0
 difficulty: 0
 timer: 0

--- a/ansible/playbooks/feed-targets.yml
+++ b/ansible/playbooks/feed-targets.yml
@@ -55,7 +55,8 @@
         player_spin: "{{player_spin|default('1')}}"
         headshot_spin: "{{headshot_spin|default('1')}}"
         writeup_allowed: "{{writeup_allowed|default('1')}}"
-        description: '{{description}}'
+        instance_allowed: "{{instance_allowed|default('1')}}"
+        description: '{{description|default("")}}'
         ipoctet: '{{ansible_host}}'
         difficulty: "{{difficulty|default('0')}}"
         mac: '{{mac}}'
@@ -116,7 +117,7 @@
 #    ignore_errors: true
     tags:
       - UI
-    when: target_id is defined and TargetOndemand is defined
+    when: target_id is defined and TargetOndemand is defined and ( TargetOndemand != 0 and TargetOndemand != false )
     uri:
       url: "{{mui.URL}}/index.php?r=restapi/target-ondemand/create&access-token={{TOKEN}}"
       validate_certs: false

--- a/docs/DOCKER-REGISTRY.md
+++ b/docs/DOCKER-REGISTRY.md
@@ -6,7 +6,7 @@ There are many ways you can do that depending on your network topology and avail
 
 The following guide will provide instructions on running your own registry.
 
-## On VPN gateway
+## On VPN gateway (OpenBSD)
 The suggested way is to run the docker registry on its own system, however the
 next best thing as far as flexibility goes is to run it on your VPN gateway and
 limit access to the registry to `dockerd` servers.
@@ -20,6 +20,7 @@ ansible-playbook --connection=local -i 127.0.0.1, runonce/docker-registry.yml
 ansible-playbook --connection=local -i 127.0.0.1, runonce/docker-registry.yml -e '@settings.yml'
 ```
 
+## On own server (OpenBSD)
 Alternatively, you can proceed with manual installation by following the steps.
 
 Install the needed packages

--- a/docs/ansible/DOCKER-TARGETS.md
+++ b/docs/ansible/DOCKER-TARGETS.md
@@ -116,7 +116,7 @@ Feed the data to the backend
 ansible-playbook playbooks/feed-targets.yml -i inventories/targets  -e '{"mui":{"URL": "http://127.0.0.1:8080"}}'
 ```
 
-You can also create a `group_vars` for the targets to include all those extra-vars details and not having to type them again
+You can also create a file at `inventories/targets/group_vars/all.yml` for the targets to include all those extra-vars details and not having to type them again
 ```yaml
 DOCKER_REGISTRY: "myregistry:5000"
 DOCKER_REPOSITORY: "targets"

--- a/frontend/composer.json
+++ b/frontend/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.4.0 || >=8",
-        "yiisoft/yii2": "~2.0.45",
+        "yiisoft/yii2": "2.0.45",
         "yiisoft/yii2-bootstrap": "~2.0.0",
         "yiisoft/yii2-bootstrap4": "^2.0",
         "overals/yii2-whois": "~1.0.0",


### PR DESCRIPTION
The following PR does
* [x] docs fixes: mention `group_vars` on docker-targets.md and operating system on docker-registry.md
* [x] add missing `variables.yml` entries that were causing the examples and sanitycheck to fail feed to the backend
* [x] add missing `instance_allowed` to `feed-targets.yml`
* [x] Attempt to pin yii2 version into a working copy for frontend (the latest one causes typecasting operations on virtual columns to fail)