### PR TITLE
add triggers for challenges and stream

### DIFF
--- a/backend/migrations/m230729_200303_update_tbd_player_delete_team_data.php
+++ b/backend/migrations/m230729_200303_update_tbd_player_delete_team_data.php
@@ -1,0 +1,35 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230729_200303_update_tad_player_delete_team_data
+ */
+class m230729_200303_update_tbd_player_delete_team_data extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tbd_player}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tbd_player}} BEFORE DELETE ON {{%player}} FOR EACH ROW
+    thisBegin:BEGIN
+      DECLARE tid INT default 0;
+      IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+      END IF;
+      SELECT id INTO tid FROM team where owner_id=OLD.id;
+      IF tid > 0 THEN
+        DELETE FROM team_score WHERE team_id=tid;
+      END IF;
+      DELETE FROM player_ssl WHERE player_id=OLD.id;
+      DELETE FROM player_rank WHERE player_id=OLD.id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m230730_100249_add_echoctf_column_to_profile_table.php
+++ b/backend/migrations/m230730_100249_add_echoctf_column_to_profile_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles adding columns to table `{{%profile}}`.
+ */
+class m230730_100249_add_echoctf_column_to_profile_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{%profile}}', 'echoctf', $this->integer()->unsigned()->after('twitch'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{%profile}}', 'echoctf');
+    }
+}

--- a/backend/migrations/m230813_215403_create_tad_challenge_trigger.php
+++ b/backend/migrations/m230813_215403_create_tad_challenge_trigger.php
@@ -1,0 +1,30 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230813_215403_create_tad_challenge_trigger
+ */
+class m230813_215403_create_tad_challenge_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_challenge}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_challenge}} AFTER DELETE ON {{%challenge}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+        DELETE FROM stream WHERE `model`='challenge' AND model_id=OLD.id;
+        DELETE FROM team_stream WHERE `model`='challenge' AND model_id=OLD.id;
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m230813_215914_create_tbd_challenge_trigger.php
+++ b/backend/migrations/m230813_215914_create_tbd_challenge_trigger.php
@@ -1,0 +1,30 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230813_215914_create_tbd_challenge_trigger
+ */
+class m230813_215914_create_tbd_challenge_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tbd_challenge}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tbd_challenge}} BEFORE DELETE ON {{%challenge}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+        DELETE FROM stream WHERE `model`='question' AND model_id IN (SELECT id FROM question WHERE challenge_id=OLD.ID);
+        DELETE FROM team_stream WHERE `model`='question' AND model_id IN (SELECT id FROM question WHERE challenge_id=OLD.ID);
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m230813_220358_create_tad_stream_trigger.php
+++ b/backend/migrations/m230813_220358_create_tad_stream_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230813_220358_create_tad_stream_trigger
+ */
+class m230813_220358_create_tad_stream_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_stream}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_stream}} AFTER DELETE ON {{%stream}} FOR EACH ROW
+    thisBegin:BEGIN
+    IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+    END IF;
+    INSERT INTO player_score (player_id,points) VALUES (OLD.player_id,-OLD.points) ON DUPLICATE KEY UPDATE points=if(points+values(points)<0,0,points+values(points));
+    END";
+
+    public function up()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+      $this->db->createCommand($this->CREATE_SQL)->execute();
+    }
+
+    public function down()
+    {
+      $this->db->createCommand($this->DROP_SQL)->execute();
+    }
+}

--- a/backend/migrations/m230814_110341_create_tad_team_stream_trigger.php
+++ b/backend/migrations/m230814_110341_create_tad_team_stream_trigger.php
@@ -1,0 +1,29 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m230814_110341_create_tad_team_stream_trigger
+ */
+class m230814_110341_create_tad_team_stream_trigger extends Migration
+{
+    public $DROP_SQL="DROP TRIGGER IF EXISTS {{%tad_team_stream}}";
+    public $CREATE_SQL="CREATE TRIGGER {{%tad_team_stream}} AFTER DELETE ON {{%team_stream}} FOR EACH ROW
+    thisBegin:BEGIN
+      IF (@TRIGGER_CHECKS = FALSE) THEN
+        LEAVE thisBegin;
+      END IF;
+      INSERT INTO {{%team_score}} ({{%team_id}},{{%points}},{{%ts}}) VALUES (OLD.team_id,-OLD.points,OLD.ts) ON DUPLICATE KEY UPDATE points=if(points+values(points)<0,0,points+values(points)),ts=values(ts);
+    END";
+
+      public function up()
+      {
+        $this->db->createCommand($this->DROP_SQL)->execute();
+        $this->db->createCommand($this->CREATE_SQL)->execute();
+      }
+
+      public function down()
+      {
+        $this->db->createCommand($this->DROP_SQL)->execute();
+      }
+}


### PR DESCRIPTION
This PR does the following

* Trigger Before Delete on player
* Introduces echoctf player column
* Trigger after delete challenge
* trigger before delete challenge
* trigger after delete on stream
* trigger after delete on team_stream

Due to the way mariadb works triggers do not fire up for related data. These triggers make sure that the related operations are performed by individual delete commands and thus making sure the score of the player and their teams is accurate.