### PR TITLE
make the target dropdown listing ordered alphabetically on player findings and treasures

### DIFF
--- a/backend/modules/activity/views/player-finding/_form.php
+++ b/backend/modules/activity/views/player-finding/_form.php
@@ -22,7 +22,7 @@ use app\widgets\sleifer\autocompleteAjax\AutocompleteAjax;
         'options' => ['placeholder' => 'Find player by email, username, id or profile.']
     ])->hint('The player that the finding will be given.');  ?>
 
-    <?= $form->field($model, 'finding_id')->dropDownList(ArrayHelper::map(Finding::find()->all(), 'id', 'name', 'target.fqdn'), ['prompt'=>'Select finding']) ?>
+    <?= $form->field($model, 'finding_id')->dropDownList(ArrayHelper::map(Finding::find()->joinWith('target')->orderBy(['target.name'=>SORT_ASC])->all(), 'id', 'name', 'target.name'), ['prompt'=>'Select finding']) ?>
 
     <?= $form->field($model, 'ts')->textInput() ?>
 

--- a/backend/modules/activity/views/player-finding/_form.php
+++ b/backend/modules/activity/views/player-finding/_form.php
@@ -24,8 +24,6 @@ use app\widgets\sleifer\autocompleteAjax\AutocompleteAjax;
 
     <?= $form->field($model, 'finding_id')->dropDownList(ArrayHelper::map(Finding::find()->joinWith('target')->orderBy(['target.name'=>SORT_ASC])->all(), 'id', 'name', 'target.name'), ['prompt'=>'Select finding']) ?>
 
-    <?= $form->field($model, 'ts')->textInput() ?>
-
     <div class="form-group">
         <?= Html::submitButton('Save', ['class' => 'btn btn-success']) ?>
     </div>

--- a/backend/modules/activity/views/player-treasure/_form.php
+++ b/backend/modules/activity/views/player-treasure/_form.php
@@ -22,9 +22,7 @@ use app\widgets\sleifer\autocompleteAjax\AutocompleteAjax;
         'options' => ['placeholder' => 'Find player by email, username, id or profile.']
     ])->hint('The player that the treasure will be given.');  ?>
 
-    <?= $form->field($model, 'treasure_id')->dropDownList(ArrayHelper::map(Treasure::find()->all(), 'id', 'name', 'target.fqdn'), ['prompt'=>'Select treasure']) ?>
-
-    <?= $form->field($model, 'ts')->textInput() ?>
+    <?= $form->field($model, 'treasure_id')->dropDownList(ArrayHelper::map(Treasure::find()->joinWith('target')->orderBy(['target.name'=>SORT_ASC])->all(), 'id', 'name', 'target.name'), ['prompt'=>'Select treasure']) ?>
 
     <div class="form-group">
         <?= Html::submitButton('Save', ['class' => 'btn btn-success']) ?>


### PR DESCRIPTION
make the target dropdown listing ordered alphabetically on player findings and treasures
fixes #1030 