### PR TITLE
dont throw status 500 on duplicate records

### DIFF
--- a/backend/modules/restapi/controllers/FindingController.php
+++ b/backend/modules/restapi/controllers/FindingController.php
@@ -1,9 +1,42 @@
 <?php
 namespace app\modules\restapi\controllers;
 
+use Yii;
+use yii\helpers\Url;
 use yii\rest\ActiveController;
+use yii\web\ServerErrorHttpException;
 
 class FindingController extends ActiveController
 {
     public $modelClass='app\modules\gameplay\models\Finding';
+    public function actions()
+    {
+        $actions = parent::actions();
+        unset($actions['create']);
+        return $actions;
+    }
+
+    public function actionCreate()
+    {
+        /* @var $model \yii\db\ActiveRecord */
+        $params=Yii::$app->getRequest()->getBodyParams();
+        if(($model=$this->modelClass::findOne(['target_id'=>$params['target_id'],'protocol'=>$params['protocol'],'port'=>$params['port']]))==null)
+        {
+            $model = new $this->modelClass([ ]);
+        }
+
+        $model->load(Yii::$app->getRequest()->getBodyParams(), '');
+
+        if ($model->save()) {
+            $response = Yii::$app->getResponse();
+            $response->setStatusCode(201);
+            $id = implode(',', $model->getPrimaryKey(true));
+            $response->getHeaders()->set('Location', Url::toRoute(['view', 'id' => $id], true));
+        } elseif (!$model->hasErrors()) {
+            throw new ServerErrorHttpException('Failed to create the object for unknown reason.');
+        }
+
+        return $model;
+    }
+
 }

--- a/backend/modules/restapi/controllers/TargetMetadataController.php
+++ b/backend/modules/restapi/controllers/TargetMetadataController.php
@@ -2,9 +2,41 @@
 namespace app\modules\restapi\controllers;
 
 use yii\rest\ActiveController;
+use Yii;
+use yii\web\ServerErrorHttpException;
+use yii\helpers\Url;
 
 class TargetMetadataController extends ActiveController
 {
     public $modelClass='app\modules\infrastructure\models\TargetMetadata';
+    public function actions()
+    {
+        $actions = parent::actions();
+        unset($actions['create']);
+        return $actions;
+    }
+
+    public function actionCreate()
+    {
+        /* @var $model \yii\db\ActiveRecord */
+        $params=Yii::$app->getRequest()->getBodyParams();
+        if(($model=$this->modelClass::findOne($params['target_id']))==null)
+        {
+            $model = new $this->modelClass([ ]);
+        }
+
+        $model->load(Yii::$app->getRequest()->getBodyParams(), '');
+
+        if ($model->save()) {
+            $response = Yii::$app->getResponse();
+            $response->setStatusCode(201);
+            $id = implode(',', $model->getPrimaryKey(true));
+            $response->getHeaders()->set('Location', Url::toRoute(['view', 'id' => $id], true));
+        } elseif (!$model->hasErrors()) {
+            throw new ServerErrorHttpException('Failed to create the object for unknown reason.');
+        }
+
+        return $model;
+    }
 
 }

--- a/backend/modules/restapi/controllers/TargetOndemandController.php
+++ b/backend/modules/restapi/controllers/TargetOndemandController.php
@@ -1,9 +1,42 @@
 <?php
 namespace app\modules\restapi\controllers;
 
-use yii\rest\ActiveController;
+use Yii;
+use yii\web\ServerErrorHttpException;
+use yii\helpers\Url;
 
-class TargetOndemandController extends ActiveController
+class TargetOndemandController extends \yii\rest\ActiveController
 {
     public $modelClass='app\modules\gameplay\models\TargetOndemand';
+
+    public function actions()
+    {
+        $actions = parent::actions();
+        unset($actions['create']);
+        return $actions;
+    }
+
+    public function actionCreate()
+    {
+        /* @var $model \yii\db\ActiveRecord */
+        $params=Yii::$app->getRequest()->getBodyParams();
+        if(($model=$this->modelClass::findOne($params['target_id']))==null)
+        {
+            $model = new $this->modelClass([ ]);
+        }
+
+        $model->load(Yii::$app->getRequest()->getBodyParams(), '');
+
+        if ($model->save()) {
+            $response = Yii::$app->getResponse();
+            $response->setStatusCode(201);
+            $id = implode(',', $model->getPrimaryKey(true));
+            $response->getHeaders()->set('Location', Url::toRoute(['view', 'id' => $id], true));
+        } elseif (!$model->hasErrors()) {
+            throw new ServerErrorHttpException('Failed to create the object for unknown reason.');
+        }
+
+        return $model;
+    }
+
 }

--- a/backend/modules/restapi/controllers/TreasureController.php
+++ b/backend/modules/restapi/controllers/TreasureController.php
@@ -2,6 +2,7 @@
 namespace app\modules\restapi\controllers;
 
 use yii\rest\ActiveController;
+use Yii;
 
 class TreasureController extends ActiveController
 {
@@ -12,11 +13,16 @@ class TreasureController extends ActiveController
       \Yii::$app->response->format=\yii\web\Response:: FORMAT_JSON;
       $connection=\Yii::$app->db;
       $transaction=$connection->beginTransaction();
+      $params=Yii::$app->getRequest()->getBodyParams();
       try
       {
-        $treasure=new \app\modules\gameplay\models\Treasure;
+        if(($treasure=$this->modelClass::findOne(['target_id'=>$params['target_id'],'code'=>$params['code']]))==null)
+        {
+          $treasure=new $this->modelClass;
+        }
         $post=\yii::$app->request->post();
-        $treasure->attributes=$post;
+        $treasure->load(Yii::$app->getRequest()->getBodyParams(), '');
+
         if($treasure->validate() && $treasure->save())
         {
           $this->doTreasureActions($post,$treasure);


### PR DESCRIPTION
The following PR changes the REST controllers for findings, treasures, target metadata and target ondemand to update existing records instead of throwing error 500 caused by attempting to create new records that are duplicate.

Fixes #1110 