### PR TITLE
Ensure our docker containers work on non https

### DIFF
--- a/ansible/Dockerfiles/example/autoregister.yml
+++ b/ansible/Dockerfiles/example/autoregister.yml
@@ -1,3 +1,4 @@
+#!/usr/bin/env ansible-playbook
 ---
 - name: Update container with gameplay data
   hosts: 127.0.0.1
@@ -17,7 +18,7 @@
       gid: "{{item.uid|default(omit)}}"
       state: present
     with_items: "{{DETAILS}}"
-    when: DETAILS is defined and item.module is defined and item.module=='user'
+    when: DETAILS is defined and item.module is defined and item.module=='user' and item.group is defined
 
   - name: users based on details
     user:
@@ -25,13 +26,12 @@
       shell: "{{item.shell|default('/bin/bash')}}"
       comment: "{{item.gecos}}"
       uid: "{{item.uid|default(omit)}}"
-      group: "{{item.group|default('nobody')}}"
+      group: "{{item.group|default(omit)}}"
       password: "{{item.password}}"
       state: present
       update_password: always
     with_items: "{{DETAILS}}"
     when: DETAILS is defined and item.module is defined and item.module=='user'
-
 
   - name: "Create flags on local filesystem"
     when: item.path is defined
@@ -39,7 +39,6 @@
     file:
       path: "{{item.path}}{{item.code}}"
       state: touch
-
 
   - name: "Create flag with content on local filesystem to be used as volumes"
     when: item.fullpath is defined
@@ -82,16 +81,6 @@
     with_items: "{{BUILD_COMMANDS.exec}}"
     raw: "{{item.cmd}}"
 
-  - name: Copy raw configs
-    when: RAW_CONFS is defined
-    copy:
-      content: "{{item.value.content}}\n"
-      dest: "{{item.key}}"
-      mode: "{{item.value.mode|default(omit)}}"
-      owner: "{{item.value.uid|default(0)}}"
-      group: "{{item.value.gid|default(0)}}"
-    with_dict: "{{RAW_CONFS}}"
-
   - name: Generate INI files
     when: INI_FILES is defined
     ini_file:
@@ -102,12 +91,6 @@
       backup: false
     with_items: "{{INI_FILES}}"
 
-  - name: Create Decoy flags
-    when: ETSCTF_DECOY is defined
-    debug:
-      var: ETSCTF_DECOY
-    with_sequence: start=1 end={{ ETSCTF_DECOY.number }}
-
   - name: Parse defined templates
     when: templates is defined
     template:
@@ -117,3 +100,19 @@
       group: "{{item.group}}"
       mode: "{{item.mode}}"
     with_items: "{{templates}}"
+
+  - name: Copy raw configs
+    when: RAW_CONFS is defined
+    copy:
+      content: "{{item.value.content}}\n"
+      dest: "{{item.key}}"
+      mode: "{{item.value.mode|default(omit)}}"
+      owner: "{{item.value.uid|default(0)}}"
+      group: "{{item.value.gid|default(0)}}"
+    with_dict: "{{RAW_CONFS}}"
+
+  - name: Create Decoy flags
+    when: ETSCTF_DECOY is defined
+    debug:
+      var: ETSCTF_DECOY
+    with_sequence: start=1 end={{ ETSCTF_DECOY.number }}

--- a/contrib/Dockerfile-frontend
+++ b/contrib/Dockerfile-frontend
@@ -30,6 +30,7 @@ RUN set -ex \
     && chmod a+x /usr/local/bin/composer \
     && sed -ie "s/127.0.0.1/${MYSQL_HOST}/g" ${RED_APP}/config/cache.php \
     && echo "<?php return [ 'class' => 'yii\db\Connection', 'dsn' => 'mysql:host=${MYSQL_HOST};dbname=${MYSQL_DATABASE}', 'username' => '${MYSQL_USER}', 'password' => '${MYSQL_PASSWORD}', 'charset' => 'utf8mb4','enableSchemaCache' => true,'schemaCacheDuration' => 0,'schemaCache' => 'cache','enableQueryCache' => true,'queryCache'=>'qcache','queryCacheDuration'=>60,];">${RED_APP}/config/db.php \
+    && sed -e "s|'secure' => true,|'secure' => false,|g" -i ${RED_APP}/config/web.php \
     && mkdir -p ${RED_APP}/web/assets ${RED_APP}/runtime ${RED_APP}/web/images/avatars/team ${RED_APP}/web/uploads\
     && chown -R www-data ${RED_APP}/web/assets ${RED_APP}/web/images/avatars \
     && chown www-data ${RED_APP}/runtime ${RED_APP}/web/uploads \

--- a/docs/DOCKER-COMPOSE.md
+++ b/docs/DOCKER-COMPOSE.md
@@ -48,7 +48,7 @@ The first time you run `docker-compose up` give the containers a few minutes to 
 
 Once the initialization process completes, run the following command to connect the mysql server with the memcached
 ```sh
-docker exec -it echoctfred_db bash -c "mysql < /etc/mysql-init.sql"
+docker exec -it echoctfred_db bash -c "mariadb < /etc/mysql-init.sql"
 ```
 
 This command will have to be run every time the database server stops or respawned by eg `docker-compose down` and only once the systems are fully initialized. You can make the change permanent by appending `, "--init_file=/etc/mysql-init.sql"` to the db `command` parameters before the closing bracket `]`.


### PR DESCRIPTION
Ensure our docker containers work on non https, by setting the cookie secure into false. 
Fixes the submission error 400 when trying to login after initial setup

issue #1334