### PR TITLE
We now require php >=8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "composer"

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -12,7 +12,7 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=8.0.0",
         "yiisoft/yii2": "2.0.50",
         "miloschuman/yii2-highcharts-widget": "^10.0",
         "kartik-v/yii2-tabs-x": "@dev",

--- a/frontend/composer.json
+++ b/frontend/composer.json
@@ -11,7 +11,7 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": ">=5.4.0 || >=8",
+        "php": ">=8.0.0",
         "yiisoft/yii2": "2.0.50",
         "yiisoft/yii2-bootstrap": "~2.0.11",
         "yiisoft/yii2-bootstrap4": "^2.0.11",


### PR DESCRIPTION
Try to fix the occasional weekly dependabot failures. For a some time now dependabot fails to perform its check due to errors in php. The problem is that this does not happen all the time but rather it occurs at random times. However when the same checks get initiated manually everything runs smoothly. Hopefully this will reduce the instances that this fail happens.