### PR TITLE
grant access to all databases since we use the set global command

### DIFF
--- a/contrib/entrypoint-mariadb.sh
+++ b/contrib/entrypoint-mariadb.sh
@@ -452,11 +452,8 @@ docker_setup_db() {
 			createUser="CREATE USER '$MARIADB_USER'@'%' IDENTIFIED BY '$userPasswordEscaped';"
 		fi
 
-		if [ -n "$MARIADB_DATABASE" ]; then
-			mysql_note "Giving user ${MARIADB_USER} access to schema ${MARIADB_DATABASE}"
-			userGrants="GRANT ALL ON \`${MARIADB_DATABASE//_/\\_}\`.* TO '$MARIADB_USER'@'%';"
-    else
-			mysql_note "Giving user ${MARIADB_USER} full access to database"
+		if [ -n "$MARIADB_USER" ]; then
+			mysql_note "Giving user ${MARIADB_USER} full access to the database server"
 			userGrants="GRANT ALL ON *.* TO '$MARIADB_USER'@'%';"
 		fi
 	fi


### PR DESCRIPTION
Make the user superuser in all cases not just when the `MARIADB_DATABASE` is empty.