### PR TITLE
Docker updates

### DIFF
--- a/.github/workflows/ci-merged-pull_requests.yml
+++ b/.github/workflows/ci-merged-pull_requests.yml
@@ -59,8 +59,8 @@ jobs:
         echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
         sudo service docker restart
 
-    - name: Build the all-in-one Docker image
-      run: docker build --squash . --file contrib/Dockerfile --tag echoctf.red-all-in-one:$(date +%s)
+#    - name: Build the all-in-one Docker image
+#      run: docker build --squash . --file contrib/Dockerfile --tag echoctf.red-all-in-one:$(date +%s)
     - name: Build the DB Docker image
       run: docker build --squash . --file contrib/Dockerfile-mariadb --tag echoctf.red-db:$(date +%s)
     - name: Build the frontend Docker image

--- a/.github/workflows/ci-pull_requests.yml
+++ b/.github/workflows/ci-pull_requests.yml
@@ -45,8 +45,8 @@ jobs:
         cd backend
         php8.3 /usr/bin/composer update --no-dev --prefer-dist --no-progress
 
-    - name: Build the all-in-one Docker image
-      run: docker build --no-cache . --file contrib/Dockerfile --tag echothrust/echoctf.red-all-in-one:latest
+#    - name: Build the all-in-one Docker image
+#      run: docker build --no-cache . --file contrib/Dockerfile --tag echothrust/echoctf.red-all-in-one:latest
     - name: Build the DB Docker image
       run: docker build --no-cache . --file contrib/Dockerfile-mariadb --tag echothrust/echoctf.red-db:latest
     - name: Build the frontend Docker image

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -84,8 +84,8 @@ jobs:
         cd backend
         php8.3 /usr/bin/composer update --no-dev --prefer-dist --no-progress
 
-    - name: Build the all-in-one Docker image
-      run: docker build --no-cache --squash . --file contrib/Dockerfile --tag echothrust/echoctf.red-all-in-one:latest
+#    - name: Build the all-in-one Docker image
+#      run: docker build --no-cache --squash . --file contrib/Dockerfile --tag echothrust/echoctf.red-all-in-one:latest
     - name: Build the DB Docker image
       run: docker build --no-cache --squash . --file contrib/Dockerfile-mariadb --tag echothrust/echoctf.red-db:latest
     - name: Build the frontend Docker image
@@ -98,8 +98,8 @@ jobs:
     - name: Login to DockerHub
       run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Push the all-in-one Docker image
-      run: docker push echothrust/echoctf.red-all-in-one:latest
+#    - name: Push the all-in-one Docker image
+#      run: docker push echothrust/echoctf.red-all-in-one:latest
     - name: Push the DB Docker image
       run: docker push echothrust/echoctf.red-db:latest
     - name: Push the frontend Docker image

--- a/backend/commands/CronController.php
+++ b/backend/commands/CronController.php
@@ -236,13 +236,15 @@ class CronController extends Controller
       {
         $ips=[];
         $dc=new DockerContainer($val->target);
-        $dc->timeout= ($val->server->timeout ? $val->server->timeout : $dc->timeout=2000);
+        $dc->timeout= ($val->server->timeout ? $val->server->timeout : 2000);
         if($val->target->targetVolumes!==null)
           $dc->targetVolumes=$val->target->targetVolumes;
         if($val->target->targetVariables!==null)
           $dc->targetVariables=$val->target->targetVariables;
         $dc->name=$val->name;
         $dc->server=$val->server->connstr;
+        $dc->net=$val->server->network;
+
         if($val->ip==null)
         {
           echo date("Y-m-d H:i:s ")."Starting";

--- a/backend/modules/infrastructure/controllers/TargetInstanceController.php
+++ b/backend/modules/infrastructure/controllers/TargetInstanceController.php
@@ -230,6 +230,7 @@ class TargetInstanceController extends \app\components\BaseController
             $dc->targetVariables=$val->target->targetVariables;
             $dc->name=$val->name;
             $dc->server=$val->server->connstr;
+            $dc->net=$val->server->network;
             try
             {
                 $dc->destroy();
@@ -243,10 +244,10 @@ class TargetInstanceController extends \app\components\BaseController
         }
         catch (\Exception $e)
         {
-            if(method_exists($e,'getErrorResponse'))
-                echo $e->getErrorResponse()->getMessage(),"\n";
-            else
-                echo $e->getMessage(),"\n";
+          if(method_exists($e,'getErrorResponse'))
+            echo $e->getErrorResponse()->getMessage(),"\n";
+          else
+            echo $e->getMessage(),"\n";
         }
 
         return $this->redirect(['index']);

--- a/backend/modules/infrastructure/models/DockerContainer.php
+++ b/backend/modules/infrastructure/models/DockerContainer.php
@@ -86,6 +86,7 @@ class DockerContainer extends Model
     $hostConfig=$this->hostConfig();
 
     $containerConfig=new ContainersCreatePostBody();
+/*
     $endpointSettings=new EndpointSettings();
     $endpointIPAMConfig=new EndpointIPAMConfig();
     $endpointIPAMConfig->setIPv4Address($this->ipoctet);// target->ipoctet
@@ -96,6 +97,7 @@ class DockerContainer extends Model
       $this->net => $endpointSettings
     ]));
     $containerConfig->setNetworkingConfig($nwc);
+*/
     $containerConfig->setHostname($this->fqdn);// target->fqdn
     $containerConfig->setImage($this->image);// target->image
     $containerConfig->setOpenStdin(true);
@@ -108,7 +110,6 @@ class DockerContainer extends Model
       $targetVariables[]=sprintf("%s=%s", $var->key, $var->val);
 
     $containerConfig->setEnv($targetVariables);
-    //$containerConfig->setMacAddress($this->mac); // target->mac
     $containerConfig->setHostConfig($hostConfig);
 
     $this->container=$this->docker->containerCreate($containerConfig, ['name'=>$this->name]);
@@ -140,7 +141,7 @@ class DockerContainer extends Model
 /*
     if(!$this->container)
     {
-      $this->container=$this->docker->getContainerManager()->find($this->name);
+     $this->container=$this->docker->getContainerManager()->find($this->name);
     }
     if($this->container instanceof \Docker\API\Model\ContainersCreatePostResponse201 )
     {

--- a/backend/modules/infrastructure/models/DockerContainer.php
+++ b/backend/modules/infrastructure/models/DockerContainer.php
@@ -43,6 +43,7 @@ class DockerContainer extends Model
   {
     parent::init();
   }
+
   public function __set($name, $value)
   {
     if(!property_exists($this,$name))
@@ -55,6 +56,7 @@ class DockerContainer extends Model
     if(is_array($value)) $this->targetVariables=$value;
     $this->targetVariables=[];
   }
+
   public function setTargetVolumes($value)
   {
     if(is_array($value)) $this->targetVolumes=$value;
@@ -80,6 +82,7 @@ class DockerContainer extends Model
   {
     $targetVariables=null;
     $this->connectAPI();
+
     $hostConfig=$this->hostConfig();
 
     $containerConfig=new ContainersCreatePostBody();
@@ -107,6 +110,7 @@ class DockerContainer extends Model
     $containerConfig->setEnv($targetVariables);
     //$containerConfig->setMacAddress($this->mac); // target->mac
     $containerConfig->setHostConfig($hostConfig);
+
     $this->container=$this->docker->containerCreate($containerConfig, ['name'=>$this->name]);
     $this->docker->containerStart($this->container->getId());
   }

--- a/backend/modules/infrastructure/models/DockerContainer.php
+++ b/backend/modules/infrastructure/models/DockerContainer.php
@@ -133,6 +133,7 @@ class DockerContainer extends Model
   public function getContainer()
   {
     $this->connectAPI();
+/*
     if(!$this->container)
     {
       $this->container=$this->docker->getContainerManager()->find($this->name);
@@ -141,7 +142,9 @@ class DockerContainer extends Model
     {
       $this->container=$this->docker->containerInspect($this->container->getId());
     }
+*/
 
+    $this->container=$this->docker->containerInspect($this->container->getId());
     return $this->container;
   }
 


### PR DESCRIPTION
This PR does the following:
* Remove the all-in-one container its not used anywhere
* Fix a logic bug on `cron/instances` which caused `timeout` to become 1second
* Add the docker-server pre-defined network on `cron/instances` and `target-instance/restart`
* Update DockerContainer logic to work with latest docker API changes