### PR TITLE
Team module improvements

### DIFF
--- a/backend/modules/frontend/controllers/TeamplayerController.php
+++ b/backend/modules/frontend/controllers/TeamplayerController.php
@@ -116,10 +116,14 @@ class TeamplayerController extends \app\components\BaseController
           Yii::$app->getUser()->setReturnUrl(Yii::$app->getSession()->get('__deleteUrl'));
           unset($_SESSION['__deleteUrl']);
         }
-
-        if($this->findModel($id)->delete()!==false)
-          Yii::$app->session->setFlash('success', "Team membership deleted.");
-
+        $model=$this->findModel($id);
+        if($model->delete()!==false)
+        {
+            // repopulate team stream
+            $t=Yii::$app->db->createCommand("CALL repopulate_team_stream(:tid)")->bindValue(':tid',$model->team_id)->execute();
+            Yii::$app->session->setFlash('success', "Team membership deleted.");
+        }
+          
         return $this->redirect(Yii::$app->request->referrer ?? ['frontend/teamplayer/index']);
     }
 

--- a/backend/modules/frontend/views/team/view.php
+++ b/backend/modules/frontend/views/team/view.php
@@ -79,13 +79,7 @@ Yii::$app->user->setReturnUrl(['frontend/team/view', 'id' => $model->id]);
       <?= GridView::widget([
         'dataProvider' => $dataProvider,
         'columns' => [
-          [
-            'attribute' => 'player',
-            'label' => 'Player',
-            'value' => function ($model) {
-              return sprintf("id:%d %s", $model->player_id, $model->player->username);
-            },
-          ],
+          ['class' => 'app\components\columns\ProfileColumn','attribute'=>'player'],
           'approved:boolean',
           'ts',
           [

--- a/frontend/modules/team/controllers/DefaultController.php
+++ b/frontend/modules/team/controllers/DefaultController.php
@@ -452,6 +452,7 @@ class DefaultController extends \app\components\BaseController
       return $this->redirect(['view', 'token' => $token]);
     }
     $redir = ['view', 'token' => $token];
+    
     if ($tp->player_id === Yii::$app->user->id) {
       if (Yii::$app->user->identity->teamLeader) {
         $this->delete_with_extras();
@@ -462,7 +463,9 @@ class DefaultController extends \app\components\BaseController
     } else {
       Yii::$app->session->setFlash('success', \Yii::t('app', 'Membership has been withdrawn.'));
     }
+
     if (Yii::$app->user->identity->teamLeader) {
+      Yii::$app->db->createCommand("CALL repopulate_team_stream(:tid)")->bindValue(':tid', $tp->team_id)->execute();
       $tp->notifyRejectPlayer();
     } else {
       $tp->notifyPartOwner();


### PR DESCRIPTION
The following PR changes:
* [x] On backend TeamPlayer delete action also re-populate the team stream
* [x] On backend Team view page make the team member usernames linked to their profiles (use our ProfileColumn model)
* [x] On frontend Team Reject action make sure we repopulate the team stream when the rejection is performed by the team leader
