### PR TITLE
Playbook improvements

### DIFF
--- a/ansible/runonce/mui.yml
+++ b/ansible/runonce/mui.yml
@@ -248,6 +248,7 @@
       - usr/local/lib
       - "usr/local/share/icu/{{versions.ICU_MAJOR}}.{{versions.ICU_MINOR}}"
       - usr/lib
+      - acme/.well-known/acme-challenge
 
   - name: "Copy pf conf files"
     copy:

--- a/ansible/runonce/mui.yml
+++ b/ansible/runonce/mui.yml
@@ -257,6 +257,8 @@
     with_items:
       - { src: '{{playbook_dir}}/../templates/pf.conf.j2', dest: '/etc/pf.conf' }
       - { src: '{{playbook_dir}}/../templates/mui.service.conf.j2', dest: '/etc/service.pf.conf' }
+      - { src: '{{playbook_dir}}/../templates/httpd.conf.j2', dest: '/etc/httpd.conf' }
+      - { src: '{{playbook_dir}}/../templates/acme-client.conf.j2', dest: '/etc/acme-client.conf' }
 
   - name: Generate pf tables files
     command: "{{item.cmd}}"

--- a/ansible/runonce/pui.yml
+++ b/ansible/runonce/pui.yml
@@ -72,7 +72,7 @@
         - Reboot the system for the changes to take effect
     rcctl:
       - { name: check_quotas, state: "disable" }
-      - { name: cron, state: "disable" }
+      - { name: cron, state: "enable" }
       - { name: ntpd, state: "enable" }
       - { name: pflogd, state: "disable" }
       - { name: slaacd, state: "disable" }
@@ -273,9 +273,15 @@
     with_items:
       - { src: '{{playbook_dir}}/../templates/pf.conf.j2', dest: '/etc/pf.conf' }
       - { src: '{{playbook_dir}}/../templates/pui.service.conf.j2', dest: '/etc/service.pf.conf' }
-      - { src: '{{playbook_dir}}/../templates/acme-client.conf.j2', dest: '/etc/acme-client.conf' }
-      - { src: '{{playbook_dir}}/../templates/httpd.conf.j2', dest: '/etc/httpd.conf' }
       - { src: '{{playbook_dir}}/../../contrib/unbound.conf', dest: '/var/unbound/etc/unbound.conf' }
+
+  - name: "Process templates"
+    template:
+      src: "{{item.src}}"
+      dest: "{{item.dest}}"
+    with_items:
+      - { src: '{{playbook_dir}}/../templates/httpd.conf.j2', dest: '/etc/httpd.conf' }
+      - { src: '{{playbook_dir}}/../templates/acme-client.conf.j2', dest: '/etc/acme-client.conf' }
 
   - name: Generate pf tables files
     copy:
@@ -285,7 +291,7 @@
     - { dest: "/etc/administrators.conf" }
     - { dest: "/etc/docker_clients.conf" }
     - { dest: "/etc/docker_servers.conf" }
-    - { dest: "/etc/maintenance.conf" }
+    - { content: "0.0.0.0/0", dest: "/etc/maintenance.conf" }
     - { dest: "/etc/moderators.conf" }
     - { dest: "/etc/registry_clients.conf" }
     - { dest: "/etc/registry_servers.conf" }

--- a/ansible/runonce/pui.yml
+++ b/ansible/runonce/pui.yml
@@ -264,6 +264,7 @@
       - usr/local/lib
       - "usr/local/share/icu/{{versions.ICU_MAJOR}}.{{versions.ICU_MINOR}}"
       - usr/lib
+      - acme/.well-known/acme-challenge
 
   - name: "Copy pf and other conf files"
     copy:

--- a/ansible/runonce/vpngw.yml
+++ b/ansible/runonce/vpngw.yml
@@ -94,6 +94,7 @@
       AUTOMAKE: "1.16"
       ICU_MAJOR: 76
       ICU_MINOR: 1
+      MARIADB_CONNECTOR: "3.4.5"
     sysctl:
       kern.bufcachepercent: 30
       kern.maxfiles: 312180
@@ -147,6 +148,7 @@
       - py3-mysqlclient
       - py3-setuptools
       - py3-netaddr
+      - py3-pip
       - supervisor
       - gnuwatch
       - go

--- a/ansible/runonce/vpngw.yml
+++ b/ansible/runonce/vpngw.yml
@@ -564,7 +564,6 @@
     - { cmd: "{{APP_DIR}}/backend/yii sysconfig/set offense_registered_tag OFFENSE_REGISTERED"}
     - { cmd: "{{APP_DIR}}/backend/yii vpn/load /etc/openvpn/openvpn_tun0.conf"}
     - { cmd: "touch /etc/administrators.conf", creates: "/etc/administrators.conf" }
-    - { cmd: "touch /etc/maintenance.conf", creates: "/etc/maintenance.conf" }
     - { cmd: "touch /etc/moderators.conf", creates: "/etc/moderators.conf" }
     - { cmd: "touch /etc/registry_clients.conf", creates: "/etc/registry_clients.conf" }
     - { cmd: "touch /etc/registry_servers.conf", creates: "/etc/registry_servers.conf" }
@@ -586,6 +585,7 @@
       content: "{{item.val}}\n"
     with_items:
       - { dest: "/etc/registry_clients.conf", val: "10.0.0.0/24"}
+      - { dest: "/etc/maintenance.conf", val: "0.0.0.0/0"}
 
   - name: "Create targets network interface hostname.{{targets_if}}"
     copy:

--- a/contrib/database_backup.sh
+++ b/contrib/database_backup.sh
@@ -1,3 +1,3 @@
 #!/bin/ksh
-MYSQLDUMP=/usr/local/bin/mysqldump
+MYSQLDUMP=/usr/local/bin/mariadb-dump
 ${MYSQLDUMP} -YKER --add-drop-table --hex-blob --triggers --tz-utc echoCTF | gzip -9 -f -o "/altroot/echoCTF-full-$(date +%Y%m%d).sql.gz"


### PR DESCRIPTION
Minor improvements to the runonce playbooks
* [x] Create LE related folders under the chroot for pui/mui
* [x] Enable cron on pui
* [x] Do not use raw copy for the acme related demon configurations but rather parse them as templates for pui/mui
* [x] Make maintenance default on pui/vpn
* [x] Add connector version and pip package on vpn
* [x] Replace mysqldump with mariadb-dump for backups