### PR TITLE
Ansible improvements

### DIFF
--- a/ansible/files/docker-registry.yml.j2
+++ b/ansible/files/docker-registry.yml.j2
@@ -13,6 +13,9 @@ http:
   addr: {{registry.ip}}:{{registry.port}}
   headers:
     X-Content-Type-Options: [nosniff]
+  tls:
+    certificate: /etc/nginx/{{myname}}-server.crt
+    key: /etc/nginx/{{myname}}-server.key
 #auth:
 #  htpasswd:
 #    realm: basic-realm

--- a/ansible/files/nstables.sh
+++ b/ansible/files/nstables.sh
@@ -10,4 +10,4 @@ _TABLE=${2:-"administrators"}
 echo "Settings: domain=>${_DOMAIN} table=>${_TABLE}"
 echo "Fetching TXT record"
 _append=$(host -t txt ${_DOMAIN}|grep -v TXT |awk -F'"' '{print $2}')
-pfctl -t ${_TABLE} -T replace ${_DOMAIN} ${_append}
+pfctl -t ${_TABLE} -T replace ${_append}

--- a/ansible/maintenance/vpnsync.yml
+++ b/ansible/maintenance/vpnsync.yml
@@ -1,0 +1,19 @@
+#!/usr/bin/env ansible-playbook
+---
+- name: "Sync VPN Configurations"
+  hosts: all
+  order: inventory
+  gather_facts: true
+  tasks:
+  - name: Fix /etc/hosts
+    copy:
+      content: "{{ etchosts }}\n"
+      dest: /etc/hosts
+
+  - name: Fix registry_clients.conf
+    copy:
+      content: "{{ PF_TABLES.registry_clients|join('\n') }}\n"
+      dest: /etc/registry_clients.conf
+
+  - name: load registry_clients.conf
+    raw: pfctl -t registry_clients -T replace -f /etc/registry_clients.conf

--- a/ansible/playbooks/feed-targets.yml
+++ b/ansible/playbooks/feed-targets.yml
@@ -70,6 +70,7 @@
         scheduled_at: "{{ scheduled_at|default(omit) }}"
 #        scheduled_at: "{{scheduled_at| default('%Y-%m-%d 00:00:00' | strftime( ( ansible_date_time.epoch | int ) ) ) }}"
         image: '{{DOCKER_REGISTRY}}/{{DOCKER_REPOSITORY}}/{{container.image | lower}}:{{container.tag|default("latest")}}'
+        parameters: '{{container.parameters|default("")}}'
         weight: '{{weight|default(0)}}'
       status_code: 201
 

--- a/ansible/runonce/docker-registry.yml
+++ b/ansible/runonce/docker-registry.yml
@@ -5,25 +5,37 @@
   become_method: doas
   gather_facts: no
   vars_prompt:
+    - name: "myname"
+      prompt: "1/8. System FQDN?"
+      default: "registry.example.com"
+      private: no
     - name: "registry_user"
-      prompt: "1/5. User to run the registry as?"
+      prompt: "2/8. User to run the registry as?"
       default: "registry"
       private: no
     - name: "registry_home"
-      prompt: "2/5. Home folder for registry user?"
+      prompt: "3/8. Home folder for registry user?"
       default: "/home/registry"
       private: no
     - name: "registry_storage"
-      prompt: "3/5. Storage location for registry images?"
+      prompt: "4/8. Storage location for registry images?"
       default: "/home/registry/storage"
       private: no
     - name: "registry_bind_ip"
-      prompt: "4/5. Registry bind IP?"
+      prompt: "5/8. Registry bind IP?"
       default: "0.0.0.0"
       private: no
     - name: "registry_bind_port"
-      prompt: "5/5. Registry bind port?"
+      prompt: "6/8. Registry bind port?"
       default: "5000"
+      private: no
+    - name: "registry_targets_if"
+      prompt: "7/8. Targets interface?"
+      default: "vio1"
+      private: no
+    - name: "registry_targets_cidr"
+      prompt: "8/8. Targets interface IP CIDR?"
+      default: "10.0.0.100/24"
       private: no
   vars:
     ansible_python_interpreter: /usr/local/bin/python3
@@ -46,9 +58,45 @@
     - rsync--
 
   tasks:
+  - name: Sync date time
+    raw: rdate pool.ntp.org
+
   - name: Install packages
-    raw: pkg_add {{item}}
-    with_items: "{{packages}}"
+    raw: "pkg_add -I {{packages| join(' ')}}"
+
+  - name: Gather facts
+    setup:
+
+  - name: Set hostname
+    hostname:
+      name: "{{myname}}"
+
+  - name: Make hostname permanent (/etc/myname)
+    copy:
+      content: "{{ myname }}\n"
+      dest: /etc/myname
+
+  - name: Configure PS1 for root and skeleton
+    lineinfile:
+      path: "{{item}}"
+      owner: root
+      group: wheel
+      mode: '0640'
+      line: "export PS1='\\u@\\H:\\w\\$ '"
+    with_items:
+      - '/etc/skel/.profile'
+      - '/root/.profile'
+
+  - name: Configure HISTFILE for root and skeleton
+    lineinfile:
+      path: "{{item}}"
+      owner: root
+      group: wheel
+      mode: '0640'
+      line: "export HISTFILE=~/.sh_history"
+    with_items:
+      - '/etc/skel/.profile'
+      - '/root/.profile'
 
   - name: Add users
     user:
@@ -66,6 +114,18 @@
       owner: root
       group: wheel
       mode: '0555'
+
+  - name: Create necessary registry PF Configurations
+    copy:
+      dest: /etc/service.pf.conf
+      owner: root
+      group: wheel
+      content: |
+        anchor "dynamic/*"
+        pass quick inet proto tcp from <service_clients> to port {{registry_bind_port}} label "service_clients"
+    with_items:
+      - { dest: "/etc/service.pf.conf", content: 'anchor "dynamic/*"\npass quick inet proto tcp from <service_clients> to port 5000 label "service_clients"\n'}
+      - { dest: "/etc/service_clients.conf", content: '{{registry_targets_cidr}}\n'}
 
   - name: Clean registry distribution
     command: rm -rf /root/distribution
@@ -95,14 +155,22 @@
     args:
       creates: /usr/local/sbin/registry
 
-  - name: Prepare registry folder
-    command: mkdir -p {{registry.storage}}
+  - name: Prepare registry folders
+    command: mkdir -p {{registry.storage}} /etc/nginx
 
   - name: Create /etc/rc.d/docker_registry
     template:
       src: "{{playbook_dir}}/../files/docker_registry.rc.j2"
       dest: "/etc/rc.d/docker_registry"
       mode: "0555"
+
+  - name: "Process templates"
+    template:
+      src: "{{item.src}}"
+      dest: "{{item.dest}}"
+    with_items:
+      - { src: '{{playbook_dir}}/../templates/httpd.conf.j2', dest: '/etc/httpd.conf', domain: '{{myname}}' }
+      - { src: '{{playbook_dir}}/../templates/acme-client.conf.j2', dest: '/etc/acme-client.conf', domain: '{{myname}}', challenge_dir: "/var/www/acme" }
 
   - name: Create /etc/docker-registry.yml
     template:
@@ -134,6 +202,33 @@
     when: item.state is defined
     with_items: "{{rcctl}}"
 
+  - name: Issue certificate for the system
+    command: "{{item}}"
+    register: ret
+    failed_when: "ret.rc == 1"
+    with_items:
+    - "pfctl -ef /etc/pf.conf"
+    - "rcctl -f start httpd"
+    - 'echo "pass quick on egress inet proto tcp to port 80" | /sbin/pfctl -a dynamic/letsencrypt -f -'
+    - "acme-client {{myname}}"
+    - "rcctl -f stop httpd"
+    - "/sbin/pfctl -a dynamic/letsencrypt -Fr"
+
+
+  - name: Configure targerts interface
+    lineinfile:
+      path: "/etc/hostname.{{registry_targets_if}}"
+      owner: root
+      group: wheel
+      mode: '0640'
+      line: "{{item}}"
+      create: yes
+    with_items:
+      - "inet {{registry_targets_cidr | ansible.utils.ipaddr('address')}} {{registry_targets_cidr | ansible.utils.ipaddr('netmask')}} NONE group targets"
+      - "up -inet6"
+
+  - name: Bring targets interface up
+    command: sh /etc/netstart {{registry_targets_if}}
 
 #  - set_fact:
 #      post_install: |

--- a/ansible/runonce/docker-registry.yml
+++ b/ansible/runonce/docker-registry.yml
@@ -6,36 +6,40 @@
   gather_facts: no
   vars_prompt:
     - name: "myname"
-      prompt: "1/8. System FQDN?"
+      prompt: "1/9. System FQDN?"
       default: "registry.example.com"
       private: no
     - name: "registry_user"
-      prompt: "2/8. User to run the registry as?"
+      prompt: "2/9. User to run the registry as?"
       default: "registry"
       private: no
     - name: "registry_home"
-      prompt: "3/8. Home folder for registry user?"
+      prompt: "3/9. Home folder for registry user?"
       default: "/home/registry"
       private: no
     - name: "registry_storage"
-      prompt: "4/8. Storage location for registry images?"
+      prompt: "4/9. Storage location for registry images?"
       default: "/home/registry/storage"
       private: no
     - name: "registry_bind_ip"
-      prompt: "5/8. Registry bind IP?"
+      prompt: "5/9. Registry bind IP?"
       default: "0.0.0.0"
       private: no
     - name: "registry_bind_port"
-      prompt: "6/8. Registry bind port?"
+      prompt: "6/9. Registry bind port?"
       default: "5000"
       private: no
     - name: "registry_targets_if"
-      prompt: "7/8. Targets interface?"
+      prompt: "7/9. Targets interface?"
       default: "vio1"
       private: no
     - name: "registry_targets_cidr"
-      prompt: "8/8. Targets interface IP CIDR?"
+      prompt: "8/9. Targets interface IP CIDR?"
       default: "10.0.0.100/24"
+      private: no
+    - name: "admins_domain"
+      prompt: "9/9. admin domain for TXT rules?"
+      default: "admin.example.com"
       private: no
   vars:
     ansible_python_interpreter: /usr/local/bin/python3
@@ -117,15 +121,19 @@
 
   - name: Create necessary registry PF Configurations
     copy:
-      dest: /etc/service.pf.conf
+      dest: "{{item.dest}}"
       owner: root
       group: wheel
-      content: |
-        anchor "dynamic/*"
-        pass quick inet proto tcp from <service_clients> to port {{registry_bind_port}} label "service_clients"
+      content: "{{item.content}}"
     with_items:
-      - { dest: "/etc/service.pf.conf", content: 'anchor "dynamic/*"\npass quick inet proto tcp from <service_clients> to port 5000 label "service_clients"\n'}
-      - { dest: "/etc/service_clients.conf", content: '{{registry_targets_cidr}}\n'}
+      - { dest: "/etc/service.pf.conf", content: "anchor \"dynamic\"\npass quick inet proto tcp from <service_clients> to port {{registry_bind_port}} label \"service_clients\"\n"}
+      - { dest: "/etc/service_clients.conf", content: "{{registry_targets_cidr}}\n"}
+
+  - name: Dump administrators PF table
+    raw: "pfctl -t administrators -T show > /etc/administrators.conf"
+
+  - name: Load new pf
+    command: pfctl -f /etc/pf.conf
 
   - name: Clean registry distribution
     command: rm -rf /root/distribution
@@ -203,17 +211,17 @@
     with_items: "{{rcctl}}"
 
   - name: Issue certificate for the system
-    command: "{{item}}"
+    raw: "{{item}}"
     register: ret
-    failed_when: "ret.rc == 1"
+    ignore_errors: true
     with_items:
-    - "pfctl -ef /etc/pf.conf"
+    - "pfctl -f /etc/pf.conf"
     - "rcctl -f start httpd"
-    - 'echo "pass quick on egress inet proto tcp to port 80" | /sbin/pfctl -a dynamic/letsencrypt -f -'
+    - 'echo "pass quick on egress inet proto tcp to port 80" | /sbin/pfctl -a dynamic -f -'
     - "acme-client {{myname}}"
     - "rcctl -f stop httpd"
-    - "/sbin/pfctl -a dynamic/letsencrypt -Fr"
-
+    - "/sbin/pfctl -a dynamic -Fr"
+    - "chmod +r /etc/nginx/{{myname}}-server.key"
 
   - name: Configure targerts interface
     lineinfile:
@@ -229,6 +237,28 @@
 
   - name: Bring targets interface up
     command: sh /etc/netstart {{registry_targets_if}}
+
+  - name: Create empty cron
+    copy:
+      dest: /tmp/empty.cron
+      content: |
+        SHELL=/bin/sh
+        PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+        HOME=/var/log
+
+  - name: Clear cron
+    raw: crontab /tmp/empty.cron
+
+  - name: Install cron entries
+    cron:
+      name: "{{item.name}}"
+      user: "root"
+      minute: "{{item.minute | default(omit)}}"
+      special_time: "{{item.special_time|default(omit)}}"
+      job: "{{item.job}}"
+    with_items:
+      - { name: "Update admin IP's", minute: "*/5", job: "-ns nstables {{admins_domain}}" }
+      - { name: "Update admin IP's at boot", special_time: "reboot", job: "-ns nstables {{admins_domain}}" }
 
 #  - set_fact:
 #      post_install: |

--- a/ansible/runonce/docker-servers.yml
+++ b/ansible/runonce/docker-servers.yml
@@ -39,12 +39,6 @@
     hostname:
       name: "{{fqdn}}"
 
-  - name: Configure resolv.conf
-    copy:
-      content: "{{resolvconf}}\n"
-      dest: /etc/resolv.conf
-    when: resolvconf is defined
-
   - name: Configure hosts
     copy:
       content: "{{etchosts}}\n"
@@ -150,6 +144,17 @@
     ignore_errors: true
     when: st_cloud_cfg.stat.isdir is defined and st_cloud_cfg.stat.isdir
 
+  - name: Clone docker-event-action
+    git:
+      repo: "https://github.com/echoCTF/docker-event-action.git"
+      dest: /opt/docker-event-action
+      accept_hostkey: yes
+      clone: yes
+      force: yes
+      depth: 1
+    tags:
+      - docker-event-action
+
   - name: Copy docker data folder structure
     synchronize:
       src: "{{item.src}}"
@@ -175,10 +180,12 @@
       - interfaces
 
   - name: Remove DHCP from interfaces
-    ansible.builtin.lineinfile:
-      path: /etc/network/interfaces
-      state: absent
-      regexp: '^iface {{network.driver_options.parent}} inet dhcp'
+    copy:
+      dest: /etc/network/interfaces
+      content: |
+        auto lo
+        iface lo inet loopback
+        source /etc/network/interfaces.d/*
     tags:
       - interfaces
 
@@ -323,17 +330,6 @@
     tags:
       - sysctl
 
-  - name: Clone docker-event-action
-    git:
-      repo: "https://github.com/echoCTF/docker-event-action.git"
-      dest: /opt/docker-event-action
-      accept_hostkey: yes
-      clone: yes
-      force: yes
-      depth: 1
-    tags:
-      - docker-event-action
-
 #  - name: Download node16 setup script
 #    no_log: "{{DEBUG|default(true)}}"
 #    ansible.builtin.get_url:
@@ -408,6 +404,12 @@
       mode: 0500
     tags:
       - ctables
+
+  - name: Configure resolv.conf
+    copy:
+      content: "{{resolvconf}}\n"
+      dest: /etc/resolv.conf
+    when: resolvconf is defined
 
   - name: Register docker-event-action with pm2
     no_log: "{{DEBUG|default(true)}}"

--- a/ansible/runonce/pui.yml
+++ b/ansible/runonce/pui.yml
@@ -166,17 +166,6 @@
       - '/etc/skel/.profile'
       - '/root/.profile'
 
-  - name: Configure HISTFILE for root and skeleton
-    lineinfile:
-      path: "{{item}}"
-      owner: root
-      group: wheel
-      mode: '0640'
-      line: "export HISTFILE=~/.sh_history"
-    with_items:
-      - '/etc/skel/.profile'
-      - '/root/.profile'
-
   - name: Configure HISTSIZE for root and skeleton
     lineinfile:
       path: "{{item}}"
@@ -265,6 +254,7 @@
       - "usr/local/share/icu/{{versions.ICU_MAJOR}}.{{versions.ICU_MINOR}}"
       - usr/lib
       - acme/.well-known/acme-challenge
+      - htdocs
 
   - name: "Copy pf and other conf files"
     copy:
@@ -274,14 +264,15 @@
       - { src: '{{playbook_dir}}/../templates/pf.conf.j2', dest: '/etc/pf.conf' }
       - { src: '{{playbook_dir}}/../templates/pui.service.conf.j2', dest: '/etc/service.pf.conf' }
       - { src: '{{playbook_dir}}/../../contrib/unbound.conf', dest: '/var/unbound/etc/unbound.conf' }
+      - { src: '{{playbook_dir}}/../../contrib/downtime.html', dest: '/home/participantUI/htdocs/index.html' }
 
   - name: "Process templates"
     template:
       src: "{{item.src}}"
       dest: "{{item.dest}}"
     with_items:
-      - { src: '{{playbook_dir}}/../templates/httpd.conf.j2', dest: '/etc/httpd.conf' }
-      - { src: '{{playbook_dir}}/../templates/acme-client.conf.j2', dest: '/etc/acme-client.conf' }
+      - { src: '{{playbook_dir}}/../templates/httpd.conf.j2', dest: '/etc/httpd.conf', domain: "{{domain_name}}"}
+      - { src: '{{playbook_dir}}/../templates/acme-client.conf.j2', dest: '/etc/acme-client.conf', domain: "{{domain_name}}", challenge_dir: "/home/participantUI/acme/.well-known/acme-challenge/" }
 
   - name: Generate pf tables files
     copy:
@@ -407,12 +398,21 @@
     tags:
       - conf
 
-  - name: Create participantUI nginx.conf
+  - name: Create nginx participantUI.conf
     template:
       src: ../templates/nginx.conf.j2
       dest: /etc/nginx/{{item.user}}.conf
     with_items:
       - { user: 'participantUI', domain: '{{domain_name}}', root: "/{{domain_name}}/frontend/web", port: 80, fpm: '127.0.0.1:9001', home: '/home/participantUI', ip: '{{pui_ext_ip}}' }
+    tags:
+      - nginx
+
+  - name: Create nginx dt.conf
+    template:
+      src: ../templates/dt.conf.j2
+      dest: /etc/nginx/dt.conf
+    with_items:
+      - { user: 'www', domain: '{{domain_name}}', root: "/htdocs" }
     tags:
       - nginx
 
@@ -494,6 +494,7 @@
     with_items:
       - enable participant
       - set participant flags -p /home/participantUI -c /etc/nginx/participantUI.conf
+      - set nginx flags -p /home/participantUI -c /etc/nginx/dt.conf
       - set syslogd flags -a /home/participantUI/dev/log
       - set ntpd flags -s
     tags:

--- a/ansible/runonce/pui.yml
+++ b/ansible/runonce/pui.yml
@@ -5,15 +5,15 @@
   gather_facts: false
   vars_prompt:
     - name: "myname"
-      prompt: "1/6. System hostname?"
+      prompt: "1/7. System hostname?"
       default: "pui.example.local"
       private: no
     - name: "pui_ext_ip"
-      prompt: "2/6. What is the external (public) IP?"
+      prompt: "2/7. What is the external (public) IP?"
       default: "1.2.3.4"
       private: no
     - name: "db_ip"
-      prompt: "3/6. What is the database server IP?"
+      prompt: "3/7. What is the database server IP?"
       default: "10.7.0.253"
       private: no
 #    - name: "GITHUB_OAUTH_TOKEN"
@@ -25,18 +25,21 @@
 #      default: "{{ lookup('pipe', 'git remote get-url origin') }}"
 #      private: no
     - name: "domain_name"
-      prompt: "4/6. Provide the domain the frontend will run on?"
+      prompt: "4/7. Provide the domain the frontend will run on?"
       default: "pui.example.com"
       private: no
     - name: "interconnect_interface"
-      prompt: "5/6. What is the interconnect interface to be used?"
+      prompt: "5/7. What is the interconnect interface to be used?"
       default: "em1"
       private: no
     - name: "pui_ip"
-      prompt: "6/6. What is the interconnect IP to be used?"
+      prompt: "6/7. What is the interconnect IP to be used?"
       default: "10.7.0.200"
       private: no
-
+    - name: "admins_domain"
+      prompt: "7/7. admin domain for TXT rules?"
+      default: "admin.example.com"
+      private: no
   vars:
     ansible_python_interpreter: /usr/local/bin/python3
     ansible_user: root
@@ -564,6 +567,8 @@
       - { name: "Generate local routes file", minute: "*/30",  job: "-ns frontend generator/routes >>/var/log/cron/routes.log" }
       - { name: "Generate local disabled-routes file", minute: "*/30",  job: "-ns frontend generator/disabled-routes >>/var/log/cron/disabled-routes.log" }
       - { name: "Generate local player-disabled-routes file", minute: "*/30",  job: "-ns frontend generator/player-disabled-routes >>/var/log/cron/player-disabled-routes.log" }
+      - { name: "Update admin IP's", minute: "*/5", job: "-ns nstables {{admins_domain}}" }
+      - { name: "Update admin IP's at boot", special_time: "reboot", job: "-ns nstables {{admins_domain}}" }
 
   - name: Install post hook
     copy:

--- a/ansible/runonce/vpngw.yml
+++ b/ansible/runonce/vpngw.yml
@@ -424,7 +424,7 @@
       dest: /usr/local/bin/composer
       mode: '0555'
 
-  - name: Create php symlink without version
+  - name: Create needed symbolic links for backend commands
     file:
       src: "{{item.src}}"
       dest: "{{item.dst}}"
@@ -464,7 +464,9 @@
 
   - name: "Prepare /etc/hostname.tun0"
     copy:
-      content: "up group offense\n"
+      content: |
+        up group offense
+        inet -arp
       dest: /etc/hostname.tun0
 
   - name: Prepare openvpn services

--- a/ansible/runonce/vpngw.yml
+++ b/ansible/runonce/vpngw.yml
@@ -7,59 +7,59 @@
   gather_facts: false
   vars_prompt:
     - name: "myname"
-      prompt: "1/16. System hostname?"
+      prompt: "1/17. System hostname?"
       default: "vpn.example.com"
       private: no
     - name: "vpngw"
-      prompt: "2/16. OpenVPN gateway hostname or IP?"
+      prompt: "2/17. OpenVPN gateway hostname or IP?"
       default: "vpn.example.com"
       private: no
     - name: "egress_if"
-      prompt: "3/16. Egress network interface (ifconfig egress)?"
+      prompt: "3/17. Egress network interface (ifconfig egress)?"
       default: "em0"
       private: no
     - name: "vpn_ext_ip"
-      prompt: "4/16. Egress interface IP?"
+      prompt: "4/17. Egress interface IP?"
       default: "192.168.1.182"
       private: no
     - name: "targets_if"
-      prompt: "5/16. Targets network interface?"
+      prompt: "5/17. Targets network interface?"
       default: "em2"
       private: no
     - name: "targets_if_ipv4"
-      prompt: "6/16. Targets network interface IPv4?"
+      prompt: "6/17. Targets network interface IPv4?"
       default: "10.0.0.254"
       private: no
     - name: "targets_subnet"
-      prompt: "7/16. Targets network subnet?"
+      prompt: "7/17. Targets network subnet?"
       default: "10.0.0.0"
       private: no
     - name: "targets_netmask"
-      prompt: "8/16. Targets network netmask?"
+      prompt: "8/17. Targets network netmask?"
       default: "255.255.0.0"
       private: no
     - name: "echoCTF_VPN_mgmt_passwd"
-      prompt: "9/16. OpenVPN managment interface password?"
+      prompt: "9/17. OpenVPN managment interface password?"
       default: "openvpn"
       private: no
     - name: "offense_network"
-      prompt: "10/16. OpenVPN client range?"
+      prompt: "10/17. OpenVPN client range?"
       default: "10.10.0.0/16"
       private: no
     - name: "db_host"
-      prompt: "11/16. Database Server IP?"
+      prompt: "11/17. Database Server IP?"
       default: "10.7.0.253"
       private: no
     - name: "db_name"
-      prompt: "12/16. Database name?"
+      prompt: "12/17. Database name?"
       default: "echoCTF"
       private: no
     - name: "db_user"
-      prompt: "13/16. Database Server user?"
+      prompt: "13/17. Database Server user?"
       default: "vpnuser"
       private: no
     - name: "db_pass"
-      prompt: "14/16. Database Server user password?"
+      prompt: "14/17. Database Server user password?"
       default: "vpnuserpass"
       private: no
 #    - name: "GITHUB_OAUTH_TOKEN"
@@ -71,12 +71,16 @@
 #      default: "{{ lookup('pipe', 'git remote get-url origin') }}"
 #      private: no
     - name: "interconnect_interface"
-      prompt: "15/16. Interconnect interface?"
+      prompt: "15/17. Interconnect interface?"
       default: "em1"
       private: no
     - name: "interconnect_interface_ip"
-      prompt: "16/16. Interconnect interface IP?"
+      prompt: "16/17. Interconnect interface IP?"
       default: "10.7.0.254"
+      private: no
+    - name: "admins_domain"
+      prompt: "16/17. admin domain for TXT rules?"
+      default: "admin.example.com"
       private: no
   vars:
     ansible_python_interpreter: /usr/local/bin/python3
@@ -618,6 +622,8 @@
       - { name: "restart targets with 24h uptime or more", minute: "*/5",  job: "{{APP_DIR}}/backend/bin/target-restart" }
       - { name: "Healthcheck", minute: "*/10",  job: "{{APP_DIR}}/backend/bin/healthcheck" }
       - { name: "Process disconnect queue", minute: "*/1",  job: "{{APP_DIR}}/backend/yii vpn/process-disconnect-queue" }
+      - { name: "Update admin IP's", minute: "*/5", job: "-ns nstables {{admins_domain}}" }
+      - { name: "Update admin IP's at boot", special_time: "reboot", job: "-ns nstables {{admins_domain}}" }
 
   - name: Install echoctf.ini for supervisord
     copy:
@@ -626,11 +632,10 @@
         [program:IndexPlusInstances]
         user = root
         environment = TERM=vt100
-        command = gnuwatch -t -n 30 "backend cron/index;backend cron/instances"
+        command = ksh -c "while true;do backend cron/index;backend cron/instances;sleep 10;done"
+        #command = gnuwatch -t -n 30 "backend cron/index;backend cron/instances"
         stdout_logfile=/var/log/supervisord-echoctf.log
         stdout_logfile_maxbytes=0
-        stderr_logfile=/var/log/supervisord-echoctf.log
-        stderr_logfile_maxbytes=0
         redirect_stderr=true
 
 

--- a/ansible/runonce/vpnslaves.yml
+++ b/ansible/runonce/vpnslaves.yml
@@ -1,0 +1,364 @@
+#!/usr/bin/env ansible-playbook
+---
+- name: "Setup OpenBSD VPN slave from snapshot"
+  hosts: all
+#  hosts: 127.0.0.1
+#  connection: local
+  gather_facts: false
+  vars_prompt:
+    - name: "myname"
+      prompt: "1/17. System hostname?"
+      default: "vpn.example.com"
+      private: no
+    - name: "vpngw"
+      prompt: "2/17. OpenVPN gateway hostname or IP?"
+      default: "vpn.example.com"
+      private: no
+    - name: "egress_if"
+      prompt: "3/17. Egress network interface (ifconfig egress)?"
+      default: "em0"
+      private: no
+    - name: "vpn_ext_ip"
+      prompt: "4/17. Egress interface IP?"
+      default: "192.168.1.182"
+      private: no
+    - name: "targets_if"
+      prompt: "5/17. Targets network interface?"
+      default: "em2"
+      private: no
+    - name: "targets_if_ipv4"
+      prompt: "6/17. Targets network interface IPv4?"
+      default: "10.0.0.254"
+      private: no
+    - name: "targets_subnet"
+      prompt: "7/17. Targets network subnet?"
+      default: "10.0.0.0"
+      private: no
+    - name: "targets_netmask"
+      prompt: "8/17. Targets network netmask?"
+      default: "255.255.0.0"
+      private: no
+    - name: "echoCTF_VPN_mgmt_passwd"
+      prompt: "9/17. OpenVPN managment interface password?"
+      default: "openvpn"
+      private: no
+    - name: "offense_network"
+      prompt: "10/17. OpenVPN client range?"
+      default: "10.10.0.0/16"
+      private: no
+    - name: "db_host"
+      prompt: "11/17. Database Server IP?"
+      default: "10.7.0.253"
+      private: no
+    - name: "db_name"
+      prompt: "12/17. Database name?"
+      default: "echoCTF"
+      private: no
+    - name: "db_user"
+      prompt: "13/17. Database Server user?"
+      default: "vpnuser"
+      private: no
+    - name: "db_pass"
+      prompt: "14/17. Database Server user password?"
+      default: "vpnuserpass"
+      private: no
+#    - name: "GITHUB_OAUTH_TOKEN"
+#      prompt: "15/18. Provide a GITHUB_OAUTH_TOKEN?"
+#      default: "randomtoken"
+#      private: no
+#    - name: "GITHUB_REPO"
+#      prompt: "16/18. Provide a github repo to clone?"
+#      default: "{{ lookup('pipe', 'git remote get-url origin') }}"
+#      private: no
+    - name: "interconnect_interface"
+      prompt: "15/17. Interconnect interface?"
+      default: "em1"
+      private: no
+    - name: "interconnect_interface_ip"
+      prompt: "16/17. Interconnect interface IP?"
+      default: "10.7.0.254"
+      private: no
+    - name: "admins_domain"
+      prompt: "16/17. admin domain for TXT rules?"
+      default: "admin.example.com"
+      private: no
+  vars:
+    ansible_python_interpreter: /usr/local/bin/python3
+    ansible_user: root
+    users:
+      - { name: _findingsd, comment: "findingsd user", password: '*' }
+    post_inst: |
+      Things to do:
+        - Update /etc/administrators.conf with your IP's
+        - Reboot the system for the changes to take effect
+    versions:
+      PHP: "8.4"
+      PHP_MINOR: "6"
+      AUTOCONF: "2.69"
+      AUTOMAKE: "1.16"
+      ICU_MAJOR: 76
+      ICU_MINOR: 1
+      MARIADB_CONNECTOR: "3.4.5"
+    sysctl:
+      kern.bufcachepercent: 30
+      kern.maxfiles: 312180
+      kern.seminfo.semmni: 1024
+      kern.seminfo.semmns: 4096
+      kern.shminfo.shmall: 32768
+      kern.shminfo.shmmax: 67018864
+      kern.somaxconn: 8192
+      net.bpf.bufsize: 2097152
+      net.bpf.maxbufsize: 4194304
+      net.inet.divert.sendspace: 65636
+      net.inet.ip.forwarding: 1
+      net.inet.ip.ifq.maxlen: 2560
+      net.inet.ip.maxqueue: 2048
+      net.inet.ip.mforwarding: 0
+      net.inet.tcp.synuselimit: 1000000
+      net.inet.udp.sendspace: 9216
+      net.unix.dgram.sendspace: 9216
+    rcctl:
+      - { name: check_quotas, state: "disable" }
+      - { name: cron, state: "enable" }
+      - { name: resolvd, state: "disable" }
+      - { name: ntpd, state: "enable" }
+      - { name: pflogd, state: "disable" }
+      - { name: slaacd, state: "disable" }
+      - { name: smtpd, state: "disable" }
+      - { name: sndiod, state: "disable" }
+      - { name: openvpn, state: "enable"}
+      - { name: mysqld, state: "enable"}
+      - { name: supervisord, state: "enable"}
+      - { name: inetd, state: "enable"}
+    packages:
+      - autoconf-2.69p3
+      - automake%1.16
+      - curl
+      - git
+      - cmake
+      - gmake
+      - rsync--
+      - libmemcached
+      - memcached--
+      - libtool
+      - mariadb-server
+      - openvpn--
+      - "pecl{{versions.PHP|replace('.','')}}-memcached"
+      - "php-gd%{{versions.PHP}}"
+      - "php-curl%{{versions.PHP}}"
+      - "php-intl%{{versions.PHP}}"
+      - "php-pdo_mysql%{{versions.PHP}}"
+      - "php-zip%{{versions.PHP}}"
+      - py3-mysqlclient
+      - py3-setuptools
+      - py3-netaddr
+      - py3-pip
+      - supervisor
+      - gnuwatch
+      - go
+      - p5-Net-Pcap
+      - p5-NetPacket
+      - gnuwatch
+      - nmap
+
+  tasks:
+  - debug:
+      msg: |
+        Before you run this playbook make sure you have applied
+        any pending migrations to the database
+
+  - name: Cleanup ssh keys
+    raw: rm /etc/ssh/ssh_host_* && ssh-keygen -A
+
+  - name: Stop supervisord
+    raw: rcctl stop supervisord
+
+  - name: Sync date time
+    raw: rdate pool.ntp.org
+
+  - name: Gather facts
+    setup:
+
+  - name: Set hostname
+    hostname:
+      name: "{{myname}}"
+
+  - name: Make hostname permanent (/etc/myname)
+    copy:
+      content: "{{ myname }}\n"
+      dest: /etc/myname
+
+  - name: Create fresh /etc/hosts
+    copy:
+      content: "127.0.0.1 localhost\n{{db_ip|default('10.7.0.253')}} db\n{{vpn_ext_ip}} {{  myname.split('.')[0] | lower }} {{ myname }}\n"
+      dest: /etc/hosts
+
+  - name: Configure interconnect interface
+    copy:
+      dest: "/etc/hostname.{{interconnect_interface}}"
+      content: |
+        inet {{ interconnect_interface_ip |default('10.7.0.254')}} 255.255.255.0 NONE group interconnect
+        up -inet6
+        up mtu 1450
+
+  - name: "Prepare /etc/hostname.tun0"
+    copy:
+      content: |
+        up group offense
+        inet -arp
+      dest: /etc/hostname.tun0
+
+  - name: Bring interconnect interface up
+    command: "{{item}}"
+    with_items:
+      - "ifconfig {{interconnect_interface}} delete"
+      - "sh /etc/netstart {{interconnect_interface}}"
+
+  - name: Set APP_DIR to /root/sources
+    when: ansible_connection != 'local'
+    set_fact:
+      APP_DIR: /root/sources
+
+  - name: Configure default services
+    command: "rcctl {{item.state}} {{item.name}}"
+    when: item.state is defined
+    with_items: "{{rcctl}}"
+
+  - name: Clone sources repo
+    when: ansible_connection != 'local' and GITHUB_REPO is defined
+    git:
+      repo: "{{GITHUB_REPO}}"
+      dest: /root/sources
+      accept_hostkey: yes
+      clone: yes
+      force: yes
+      depth: 1
+      version: "{{ GITHUB_REPO_BRANCH | default('main') }}"
+
+  - name: Set findings keylifetime to 30 hours
+    shell: rcctl set findingsd flags -l pflog1 -n echoCTF -u openvpn -p openvpn -h 127.0.0.1 -k 108000 -U _memcached
+
+  - name: Create temporary findingsd-federated.sql
+    template:
+      src: "{{playbook_dir}}/../../contrib/findingsd-federated.sql"
+      dest: /tmp/findingsd.sql
+
+  - name: Create echoctf_updown_mysql.sh
+    template:
+      src:  "{{playbook_dir}}/../../contrib/echoctf_updown_mysql.sh"
+      dest: /etc/openvpn/echoctf_updown_mysql.sh
+      mode: "0555"
+    vars:
+      db:
+        host: "{{db_host}}"
+        user: "openvpn"
+        pass: "openvpn"
+
+  - name: Update files with provided ip ranges
+    replace:
+      path: '{{item.file}}'
+      regexp: '{{item.regexp}}'
+      replace: '{{item.replace}}'
+    with_items:
+      - { file: '/etc/pf.conf', regexp: '10\.10\.0\.0\/16', replace: '{{offense_network}}' }
+      - { file: '/etc/service.pf.conf', regexp: '10\.10\.0\.1', replace: '{{ offense_network | ipaddr("next_usable") }}' }
+      - { file: '/etc/openvpn/openvpn_tun0.conf', regexp: '10\.10\.0\.0 255\.255\.0\.0', replace: '{{ offense_network | replace("/" ~ offense_network.split("/")[-1], "") }} {{ offense_network | ipaddr("netmask") }}' }
+      - { file: '/etc/openvpn/echoctf_updown_mysql.sh', regexp: '11211', replace: '{{memc_port}}' }
+
+  - name: "Create targets network interface hostname.{{targets_if}}"
+    copy:
+      content: |
+        inet {{targets_if_ipv4}} {{targets_netmask}} NONE group targets
+        up -inet6
+        up mtu 1450
+      dest: "/etc/hostname.{{targets_if}}"
+
+  - name: Bring rest of interfaces up
+    command: "{{item}}"
+    with_items:
+      - "rcctl stop openvpn"
+      - "ifconfig tun0 delete"
+      - "ifconfig {{targets_if}} delete"
+      - "sh /etc/netstart {{targets_if}}"
+      - "sh /etc/netstart tun0"
+      - "rcctl start openvpn"
+
+  - name: Get OVPN Config
+    ignore_errors: true
+    command: "{{item.cmd}}"
+    args:
+      creates: "{{item.creates|default(omit)}}"
+      chdir: "{{item.chdir|default(omit)}}"
+    with_items:
+    - { cmd: "{{APP_DIR}}/backend/yii vpn/save /etc/openvpn/openvpn_tun0.conf"}
+
+  - name: Bring rest of interfaces up
+    command: "{{item}}"
+    with_items:
+      - "rcctl stop openvpn"
+      - "ifconfig tun0 delete"
+      - "sh /etc/netstart tun0"
+      - "rcctl start openvpn"
+
+  - name: Create empty cron
+    copy:
+      dest: /tmp/empty.cron
+      content: |
+        SHELL=/bin/sh
+        PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin"
+        HOME=/var/log
+
+  - name: Clear cron
+    raw: crontab /tmp/empty.cron
+
+  - name: Install cron entries
+    cron:
+      name: "{{item.name}}"
+      user: "root"
+      minute: "{{item.minute | default(omit)}}"
+      special_time: "{{item.special_time|default(omit)}}"
+      job: "{{item.job}}"
+    with_items:
+      - { name: "Generate CRL", minute: "*/1",  job: "{{APP_DIR}}/backend/bin/ssl-generate-crl" }
+      - { name: "Process disconnect queue", minute: "*/1",  job: "{{APP_DIR}}/backend/yii vpn/process-disconnect-queue" }
+      - { name: "Update admin IP's", minute: "*/5", job: "-ns nstables {{admins_domain}}" }
+      - { name: "Update admin IP's at boot", special_time: "reboot", job: "-ns nstables {{admins_domain}}" }
+
+  - name: Install echoctf.ini for supervisord
+    copy:
+      dest: /etc/supervisord.d/echoctf.ini
+      content: |
+        [program:echoctfcron]
+        user = root
+        environment = TERM=vt100
+        command = ksh -c "while true;do /usr/local/bin/backend cron/pf 1;/usr/local/bin/backend cron/instance-pf 30; sleep 10;done"
+        stdout_logfile=/var/log/supervisord-echoctf.log
+        stdout_logfile_maxbytes=0
+        redirect_stderr=true
+
+  - name: Import echoCTF mysql schemas
+    ignore_errors: true
+    mysql_db:
+      state: import
+      name: echoCTF
+      target: "{{item}}"
+      login_user: "root"
+      login_unix_socket: "/var/run/mysql/mysql.sock"
+    with_items:
+      - "/usr/src/memcached_functions_mysql/sql/install_functions.sql"
+      - "/tmp/findingsd.sql"
+
+  - name: Execute fw_update
+    command: fw_update -a
+
+  - name: Execute syspatch
+    command: syspatch
+    failed_when: result.rc not in [0,2]
+    register: result
+
+  - name: Re-Execute syspatch in case it updated it self on the previous run
+    command: syspatch
+    failed_when: result.rc not in [0,2]
+    register: result
+
+  - debug: msg={{ post_inst.split('\n') }}

--- a/ansible/templates/acme-client.conf.j2
+++ b/ansible/templates/acme-client.conf.j2
@@ -21,7 +21,7 @@ authority buypass-test {
 }
 
 domain {{item.domain}} {
-  challengedir "/home/participantUI/acme/.well-known/acme-challenge/"
+  challengedir "{{item.challenge_dir}}"
 	domain key "/etc/nginx/{{item.domain}}-server.key"
 	domain full chain certificate "/etc/nginx/{{item.domain}}-server.crt"
   sign with letsencrypt

--- a/ansible/templates/default-settings.yml
+++ b/ansible/templates/default-settings.yml
@@ -16,3 +16,5 @@ db_host: "172.24.0.253"
 db_name: "echoCTF"
 db_user: "vpnuser"
 db_pass: "vpnuserpass"
+memc_port: 11211
+admins_domain: admin.example.com

--- a/ansible/templates/dt.conf.j2
+++ b/ansible/templates/dt.conf.j2
@@ -1,0 +1,52 @@
+user {{item.user}};
+worker_processes          5;
+worker_rlimit_nofile  1024;
+error_log  syslog:server=unix:/dev/log,severity=notice;
+pid                       logs/echoctf.dt-nginx.pid;
+
+events {
+    worker_connections    1024;
+}
+
+http {
+    include               mime.types;
+    default_type          application/octet-stream;
+    index                 /index.html;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  syslog:server=unix:/dev/log,severity=notice main;
+
+    keepalive_timeout     65;
+    gzip                  on;
+    server_tokens         off;
+
+    server {
+        listen       127.0.0.1:8080;
+        listen       127.0.0.1:8443 ssl;
+        server_name  {{item.domain}} default _ "";
+        root         /htdocs;
+
+        ssl_certificate           /etc/nginx/{{item.domain}}-server.crt;
+        ssl_certificate_key       /etc/nginx/{{item.domain}}-server.key;
+        ssl_session_timeout 5m;
+        ssl_session_cache shared:SSL:10m;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+        ssl_prefer_server_ciphers on;
+        ssl_dhparam /etc/ssl/private/dhparam.pem;
+
+        return 503;
+        error_page   503  @maintenance;
+        location @maintenance {
+            add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
+            add_header X-Frame-Options DENY;
+            add_header X-Content-Type-Options nosniff;
+            add_header X-XSS-Protection "1; mode=block";
+            add_header Retry-After 600 always;
+            rewrite ^(.*)$ /index.html break;
+        }
+    }
+
+}

--- a/ansible/templates/echoctf-slave-vpn.ini
+++ b/ansible/templates/echoctf-slave-vpn.ini
@@ -1,0 +1,8 @@
+[program:echoctfcron]
+user = root
+environment = TERM=vt100
+#command = gnuwatch -t -n 10 "/usr/local/bin/backend cron/pf 1;/usr/local/bin/backend cron/instance-pf 30"
+command = ksh -c "while true;do /usr/local/bin/backend cron/pf 1;/usr/local/bin/backend cron/instance-pf 30; sleep 10;done"
+stdout_logfile=/var/log/supervisord-echoctf.log
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/contrib/downtime.html
+++ b/contrib/downtime.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>echoCTF Temporary Downtime</title>
+<style>
+  body { text-align: center; padding: 150px; background: #222; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #cecece; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+</style>
+
+<img width="480px" src="https://raw.githubusercontent.com/echoCTF/echoCTF.RED/refs/heads/master/frontend/web/images/logo-red.png">
+<article>
+    <h1>We&rsquo;ll be back soon!</h1>
+    <div>
+      <p><b>echoCTF surgery underway:</b> We are currently updating our systems. We will be back in a few minutes.</p>
+      <p>Thank you for your understanding</p>
+      <p>&mdash; the echoCTF team</p>
+    </div>
+</article>

--- a/contrib/findingsd-federated.sql
+++ b/contrib/findingsd-federated.sql
@@ -131,7 +131,7 @@ BEGIN
   DECLARE userMAC VARCHAR(32) DEFAULT NULL;
 
   IF (select memc_server_count()<1) THEN
-    select memc_servers_set('{{db_host}}') INTO @memc_server_set_status;
+    select memc_servers_set('{{db_host}}:{{memc_port|default(11211)}}') INTO @memc_server_set_status;
   END IF;
   SELECT memc_get('sysconfig:debug') INTO @debug;
   SELECT memc_get('sysconfig:mac_auth') INTO mac_auth;


### PR DESCRIPTION
This PR introduces a lot of improvements to the ansible playbooks. Prior we had to perform a lot of steps by hand for various special installations, which now are handled by the playbooks. 

These include:
* [ ] Ability to configure multiple VPN servers
* [ ] TLS registry support and automatic generation of LetsEncrypt certificates
* [ ] Introduction of a simple vpnsync playbook to sync configuration changes across multiple VPN servers
* [ ] Ability to add docker container parameters from feed-target (eg memory limits)
* [ ] Remove arp support from tun interfaces
* [ ] Ability to set specific memcached ports for VPN servers