### PR TITLE
Online players only notification

### DIFF
--- a/backend/modules/frontend/models/Player.php
+++ b/backend/modules/frontend/models/Player.php
@@ -165,11 +165,13 @@ class Player extends PlayerAR
       else
         $publisher->publish($this->id, 'notification', ['type' => $type, 'title' => $title, 'body' => $body]);
     } catch (\Throwable $e) {
-      // on publishing error make sure we store the noticication as pending
+      // on publishing error make sure we store the notification as pending
       $cc = true;
       $archive = false;
       Yii::error($e->getMessage());
     }
+
+    if($this->online!=1) $archive = false;
 
     if ($cc === true) {
       $n = new \app\modules\activity\models\Notification;


### PR DESCRIPTION
If the player is not currently online, make sure we set the notification archive to false so that players have a chance of seeing the notification.


Fixes #1681