### PR TITLE
Vpnserver fixes

### DIFF
--- a/ansible/files/pf.conf
+++ b/ansible/files/pf.conf
@@ -22,6 +22,8 @@ table <offense_network> persist counters { 10.10.0.0/16 }
 table <heartbeat> persist counters
 table <venue> persist counters
 table <banned> persist counters
+table <rule_flush_only> persist
+table <vip_flush_only> persist
 
 set skip on lo
 

--- a/ansible/files/vpn.service.conf
+++ b/ansible/files/vpn.service.conf
@@ -46,7 +46,7 @@ anchor "networks"
 load anchor "networks" from "/etc/targets_networks.conf"
 load anchor "offense/findings" from "/etc/match-findings-pf.conf"
 
-pass quick inet to <targets> tagged OFFENSE_REGISTERED allow-opts received-on tun keep state (max 100000, source-track rule, max-src-states 2000, max-src-conn 10)
+pass quick inet to <targets> tagged OFFENSE_REGISTERED allow-opts received-on tun keep state (max 30000, source-track rule, max-src-states 250, max-src-conn 15, overload <rule_flush_only> flush)
 
 pass quick inet proto tcp from <docker_clients> to <docker_servers> port {2376}
 

--- a/ansible/runonce/vpnslaves.yml
+++ b/ansible/runonce/vpnslaves.yml
@@ -237,7 +237,7 @@
       version: "{{ GITHUB_REPO_BRANCH | default('main') }}"
 
   - name: Set findings keylifetime to 30 hours
-    shell: rcctl set findingsd flags -l pflog1 -n echoCTF -u openvpn -p openvpn -h 127.0.0.1 -k 108000 -U _memcached
+    shell: rcctl set findingsd flags -l pflog1 -n echoCTF -u openvpn -p openvpn -h 127.0.0.1 -U _memcached
 
   - name: Create temporary findingsd-federated.sql
     template:

--- a/backend/migrations-init/m241108_100648_populate_default_sysconfig_keys.php
+++ b/backend/migrations-init/m241108_100648_populate_default_sysconfig_keys.php
@@ -51,6 +51,7 @@ class m241108_100648_populate_default_sysconfig_keys extends Migration
     'profile_settings_fields'=>'avatar,bio,country,discord,email,fullname,github,pending_progress,twitch,twitter,username,visibility,youtube',
     'time_zone'=>'UTC',
     'writeup_rankings'=>1,
+    'pf_state_limits'=>'(max 500, source-track rule, max-src-states 30, max-src-conn 5, max-src-conn-rate 20/5, overload <vip_flush_only> flush)'
   ];
   /**
    * {@inheritdoc}

--- a/contrib/sample-migrations/m000000_000001_system_settings.php
+++ b/contrib/sample-migrations/m000000_000001_system_settings.php
@@ -102,7 +102,7 @@ class m000000_000001_system_settings extends Migration
     ['id' => "spins_per_day", 'val' => "70"],
     ['id' => "target_days_new", 'val' => "1"],
     ['id' => "target_days_updated", 'val' => "0"],
-    ['id' => 'pf_state_limits', 'val' => '(max 10000, source-track rule, max-src-nodes 5, max-src-states 1000, max-src-conn 50)'],
+    ['id' => 'pf_state_limits', 'val' => '(max 500, source-track rule, max-src-states 30, max-src-conn 5, max-src-conn-rate 20/5, overload <vip_flush_only> flush)'],
   ];
   public $disabled_routes = [
     //        ['route'=>'/challenge%'],


### PR DESCRIPTION
This PR changes the default settings for limiting the states per player for global and private instances. 

The details assumed are:
* 100 players per vpn server
* 5 players per team
